### PR TITLE
Warn user about potentially wrong EntityType

### DIFF
--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -101,7 +101,7 @@ def raw_inputs_to_entitites_data(
                 parsed_sequence: list | None = constituents_of_modified_fasta(
                     input.sequence
                 )
-                assert parsed_sequence is not None
+                assert parsed_sequence is not None, f'incorrect FASTA: {parsed_sequence=} '
                 expanded_sequence = [
                     get_residue_name(r, entity_type=entity_type) if len(r) == 1 else r
                     for r in parsed_sequence

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -51,7 +51,7 @@ def get_lig_residues(
 def get_polymer_residues(
     residue_names: list[str],
     entity_type: EntityType,
-):
+) -> list[Residue]:
     residues = []
     for i, residue_name in enumerate(residue_names):
         residues.append(
@@ -95,7 +95,7 @@ def raw_inputs_to_entitites_data(
                 residues = get_lig_residues(smiles=input.sequence)
 
             case EntityType.PROTEIN | EntityType.RNA | EntityType.DNA:
-                parsed_sequence: list = parse_modified_fasta_sequence(
+                parsed_sequence: list[str] = parse_modified_fasta_sequence(
                     input.sequence, entity_type
                 )
                 residues = get_polymer_residues(parsed_sequence, entity_type)

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -101,7 +101,9 @@ def raw_inputs_to_entitites_data(
                 parsed_sequence: list | None = constituents_of_modified_fasta(
                     input.sequence
                 )
-                assert parsed_sequence is not None, f'incorrect FASTA: {parsed_sequence=} '
+                assert (
+                    parsed_sequence is not None
+                ), f"incorrect FASTA: {parsed_sequence=} "
                 expanded_sequence = [
                     get_residue_name(r, entity_type=entity_type) if len(r) == 1 else r
                     for r in parsed_sequence

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -192,7 +192,7 @@ def read_inputs(fasta_file: str | Path, length_limit: int | None = None) -> list
     for desc, sequence in sequences:
         logger.info(f"[fasta] [{fasta_file}] {desc} {len(sequence)}")
         # get the type of the sequence
-        entity_str = desc.split("|")[0].strip()
+        entity_str = desc.split("|")[0].strip().lower()
         match entity_str:
             case "protein":
                 entity_type = EntityType.PROTEIN

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -12,6 +12,7 @@ from chai_lab.data.dataset.structure.all_atom_residue_tokenizer import (
 )
 from chai_lab.data.dataset.structure.chain import Chain
 from chai_lab.data.parsing.fasta import parse_modified_fasta_sequence, read_fasta
+from chai_lab.data.parsing.input_validation import identify_potential_entity_types
 from chai_lab.data.parsing.structure.all_atom_entity_data import AllAtomEntityData
 from chai_lab.data.parsing.structure.entity_type import EntityType
 from chai_lab.data.parsing.structure.residue import Residue, get_restype
@@ -204,6 +205,16 @@ def read_inputs(fasta_file: str | Path, length_limit: int | None = None) -> list
                 entity_type = EntityType.DNA
             case _:
                 raise ValueError(f"{entity_str} is not a valid entity type")
+
+        possible_types = identify_potential_entity_types(sequence)
+        if len(possible_types) == 0:
+            logger.error(f"Provided {sequence=} is invalid")
+        elif entity_type not in possible_types:
+            types_fmt = "/".join(str(et.name) for et in possible_types)
+            logger.warning(
+                f"Provided {sequence=} is likely {types_fmt}, not {entity_type.name}"
+            )
+
         retval.append(Input(sequence, entity_type.value))
         total_length += len(sequence)
 

--- a/chai_lab/data/dataset/structure/utils.py
+++ b/chai_lab/data/dataset/structure/utils.py
@@ -23,6 +23,7 @@ def get_centre_atom_name(residue_name: str) -> str:
     }:
         return "C1'"
     else:
+        assert len(residue_name) == 3, "residue expected"
         return "CA"
 
 

--- a/chai_lab/data/parsing/fasta.py
+++ b/chai_lab/data/parsing/fasta.py
@@ -35,6 +35,8 @@ def get_residue_name(
     fasta_code: str,
     entity_type: EntityType,
 ) -> str:
+    if len(fasta_code) != 1:
+        raise ValueError("Cannot handle non-single chars: {}".format(fasta_code))
     match entity_type:
         case EntityType.PROTEIN:
             return restype_1to3_with_x.get(fasta_code, "UNK")
@@ -48,8 +50,8 @@ def get_residue_name(
 
 def parse_modified_fasta_sequence(sequence: str, entity_type: EntityType) -> list[str]:
     """
-    Parses a fasta-like string containing modified residues
-     in brackets, returns a list of residue codes.
+    Parses a fasta-like string containing modified residues in brackets.
+    Returns a list of residue codes expanded to their full names (e.g., K > LYS)
     """
     pattern = r"[A-Z]|\[[A-Z0-9]+\]"
     residues = re.findall(pattern, sequence)

--- a/chai_lab/data/parsing/fasta.py
+++ b/chai_lab/data/parsing/fasta.py
@@ -48,8 +48,8 @@ def get_residue_name(
 
 def parse_modified_fasta_sequence(sequence: str, entity_type: EntityType) -> list[str]:
     """
-    Parses a fasta-like string containing modified residues in
-    brackets, returns a list of residue codes
+    Parses a fasta-like string containing modified residues
+     in brackets, returns a list of residue codes.
     """
     pattern = r"[A-Z]|\[[A-Z0-9]+\]"
     residues = re.findall(pattern, sequence)

--- a/chai_lab/data/parsing/fasta.py
+++ b/chai_lab/data/parsing/fasta.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from pathlib import Path
 from typing import Iterable
 
@@ -46,20 +45,3 @@ def get_residue_name(
             return nucleic_acid_1_to_name.get((fasta_code, entity_type), unk)
         case _:
             raise ValueError(f"Invalid polymer entity type {entity_type}")
-
-
-def parse_modified_fasta_sequence(sequence: str, entity_type: EntityType) -> list[str]:
-    """
-    Parses a fasta-like string containing modified residues in brackets.
-    Returns a list of residue codes expanded to their full names (e.g., K > LYS)
-    """
-    pattern = r"[A-Z]|\[[A-Z0-9]+\]"
-    residues = re.findall(pattern, sequence)
-
-    # get full residue name if regular fasta code (not in brackets),
-    # otherwise return what user passed in brackets
-    parsed_residues = [
-        get_residue_name(x, entity_type) if not x.startswith("[") else x.strip("[]")
-        for x in residues
-    ]
-    return parsed_residues

--- a/chai_lab/data/parsing/input_validation.py
+++ b/chai_lab/data/parsing/input_validation.py
@@ -1,0 +1,73 @@
+"""
+Simple heuristics that can help with identification of EntityType
+"""
+
+import string
+from string import ascii_letters
+
+from chai_lab.data.parsing.structure.entity_type import EntityType
+
+
+def constituents_of_modified_fasta(x: str) -> list[str] | None:
+    """
+    Accepts RNA/DNA inputs: 'agtc', 'AGT[ASP]TG', etc
+    Returns constituents, e.g, [A, G, T, ASP, T, G] or None if string is incorrect
+    """
+    x = x.strip().upper()
+    # it is a bit strange that digits are here, but [NH2] was in one protein
+    allowed_chars = ascii_letters + "[]" + string.digits
+    if not all(letter in allowed_chars for letter in x):
+        return None
+
+    current_modified: str | None = None
+
+    constituents = []
+    for letter in x:
+        if letter == "[":
+            if current_modified is not None:
+                return None  # double open bracket
+            current_modified = ""
+        elif letter == "]":
+            if current_modified is None:
+                return None  # closed without opening
+            if len(current_modified) == 0:
+                return None  # empty modification: []
+
+            current_modified = None
+        else:
+            if current_modified is not None:
+                current_modified += letter
+            else:
+                if letter not in ascii_letters:
+                    return None  # strange single-letter residue
+                constituents.append(letter)
+    if current_modified is not None:
+        return None  # did not close bracket
+    return constituents
+
+
+def identify_potential_entity_types(sequence: str) -> list[EntityType]:
+    """
+    Provided FASTA sequence or smiles, lists which entities those could be.
+    Returns an empty list if sequence is invalid for all entity types.
+    """
+    sequence = sequence.strip()
+    if len(sequence) == 0:
+        return []
+    possible_entity_types = []
+
+    constituents = constituents_of_modified_fasta(sequence)
+    if constituents is not None:
+        # this can be RNA/DNA/protein.
+        one_letter_constituents = set(x for x in constituents if len(x) == 1)
+        if set.issubset(one_letter_constituents, set("AGTC")):
+            possible_entity_types.append(EntityType.DNA)
+        if set.issubset(one_letter_constituents, set("AGUC")):
+            possible_entity_types.append(EntityType.RNA)
+        if "U" not in one_letter_constituents:
+            possible_entity_types.append(EntityType.PROTEIN)
+
+    ascii_symbols = string.ascii_letters + string.digits + ".-+=#$%:/\\[]()@"
+    if set.issubset(set(sequence.upper()), set(ascii_symbols)):
+        possible_entity_types.append(EntityType.LIGAND)
+    return possible_entity_types

--- a/chai_lab/data/parsing/input_validation.py
+++ b/chai_lab/data/parsing/input_validation.py
@@ -31,8 +31,8 @@ def constituents_of_modified_fasta(x: str) -> list[str] | None:
         elif letter == ")":
             if current_modified is None:
                 return None  # closed without opening
-            if len(current_modified) == 0:
-                return None  # empty modification: ()
+            if len(current_modified) <= 1:
+                return None  # empty modification: () or single (K)
             constituents.append(current_modified)
             current_modified = None
         else:

--- a/chai_lab/data/parsing/input_validation.py
+++ b/chai_lab/data/parsing/input_validation.py
@@ -15,7 +15,7 @@ def constituents_of_modified_fasta(x: str) -> list[str] | None:
     """
     x = x.strip().upper()
     # it is a bit strange that digits are here, but [NH2] was in one protein
-    allowed_chars = ascii_letters + "[]" + string.digits
+    allowed_chars = ascii_letters + "()" + string.digits
     if not all(letter in allowed_chars for letter in x):
         return None
 
@@ -23,16 +23,16 @@ def constituents_of_modified_fasta(x: str) -> list[str] | None:
 
     constituents = []
     for letter in x:
-        if letter == "[":
+        if letter == "(":
             if current_modified is not None:
                 return None  # double open bracket
             current_modified = ""
-        elif letter == "]":
+        elif letter == ")":
             if current_modified is None:
                 return None  # closed without opening
             if len(current_modified) == 0:
-                return None  # empty modification: []
-
+                return None  # empty modification: ()
+            constituents.append(current_modified)
             current_modified = None
         else:
             if current_modified is not None:

--- a/chai_lab/data/parsing/input_validation.py
+++ b/chai_lab/data/parsing/input_validation.py
@@ -10,7 +10,7 @@ from chai_lab.data.parsing.structure.entity_type import EntityType
 
 def constituents_of_modified_fasta(x: str) -> list[str] | None:
     """
-    Accepts RNA/DNA inputs: 'agtc', 'AGT[ASP]TG', etc
+    Accepts RNA/DNA inputs: 'agtc', 'AGT[ASP]TG', etc. Does not accept SMILES strings.
     Returns constituents, e.g, [A, G, T, ASP, T, G] or None if string is incorrect
     """
     x = x.strip().upper()
@@ -67,7 +67,7 @@ def identify_potential_entity_types(sequence: str) -> list[EntityType]:
         if "U" not in one_letter_constituents:
             possible_entity_types.append(EntityType.PROTEIN)
 
-    ascii_symbols = string.ascii_letters + string.digits + ".-+=#$%:/\\[]()@"
+    ascii_symbols = string.ascii_letters + string.digits + ".-+=#$%:/\\[]()<>@"
     if set.issubset(set(sequence.upper()), set(ascii_symbols)):
         possible_entity_types.append(EntityType.LIGAND)
     return possible_entity_types

--- a/chai_lab/data/parsing/input_validation.py
+++ b/chai_lab/data/parsing/input_validation.py
@@ -10,8 +10,9 @@ from chai_lab.data.parsing.structure.entity_type import EntityType
 
 def constituents_of_modified_fasta(x: str) -> list[str] | None:
     """
-    Accepts RNA/DNA inputs: 'agtc', 'AGT[ASP]TG', etc. Does not accept SMILES strings.
-    Returns constituents, e.g, [A, G, T, ASP, T, G] or None if string is incorrect
+    Accepts RNA/DNA inputs: 'agtc', 'AGT(ASP)TG', etc. Does not accept SMILES strings.
+    Returns constituents, e.g, [A, G, T, ASP, T, G] or None if string is incorrect.
+    Everything in returned list is single character, except for blocks specified in brackets.
     """
     x = x.strip().upper()
     # it is a bit strange that digits are here, but [NH2] was in one protein

--- a/tests/example_inputs.py
+++ b/tests/example_inputs.py
@@ -5,6 +5,7 @@ example_ligands = [
     "[O-]S(=O)(=O)[O-]",
     "CC1=C(C(CCC1)(C)C)/C=C/C(=C/C=C/C(=C/C=O)/C)/C",
     "CCC1=C(c2cc3c(c(c4n3[Mg]56[n+]2c1cc7n5c8c(c9[n+]6c(c4)C(C9CCC(=O)OC/C=C(\C)/CCC[C@H](C)CCC[C@H](C)CCCC(C)C)C)[C@H](C(=O)c8c7C)C(=O)OC)C)C=C)C=O",
+    r"C=CC1=C(C)/C2=C/c3c(C)c(CCC(=O)O)c4n3[Fe@TB16]35<-N2=C1/C=c1/c(C)c(C=C)/c(n13)=C/C1=N->5/C(=C\4)C(CCC(=O)O)=C1C",
     # different ions
     "[Mg+2]",
     "[Na+]",

--- a/tests/example_inputs.py
+++ b/tests/example_inputs.py
@@ -1,0 +1,31 @@
+example_ligangs = [
+    "C",
+    "O",
+    "C(C1C(C(C(C(O1)O)O)O)O)O",
+    "[O-]S(=O)(=O)[O-]",
+    "CC1=C(C(CCC1)(C)C)/C=C/C(=C/C=C/C(=C/C=O)/C)/C",
+    "CCC1=C(c2cc3c(c(c4n3[Mg]56[n+]2c1cc7n5c8c(c9[n+]6c(c4)C(C9CCC(=O)OC/C=C(\C)/CCC[C@H](C)CCC[C@H](C)CCCC(C)C)C)[C@H](C(=O)c8c7C)C(=O)OC)C)C=C)C=O",
+    # different ions
+    "[Mg+2]",
+    "[Na+]",
+    "[Cl-]",
+]
+
+example_proteins = [
+    "AGSHSMRYFSTSVSRPGRGEPRFIAVGYVDDTQFVR",
+    "[KCJ][SEP][PPN][B3S][BAL][PPN]K[NH2]",
+    "XDHPX",
+]
+
+
+example_rna = [
+    "AGUGGCUA",
+    "AAAAAA",
+    "AGUC",
+]
+
+example_dna = [
+    "AGTGGCTA",
+    "AAAAAA",
+    "AGTC",
+]

--- a/tests/example_inputs.py
+++ b/tests/example_inputs.py
@@ -13,7 +13,7 @@ example_ligangs = [
 
 example_proteins = [
     "AGSHSMRYFSTSVSRPGRGEPRFIAVGYVDDTQFVR",
-    "[KCJ][SEP][PPN][B3S][BAL][PPN]K[NH2]",
+    "(KCJ)(SEP)(PPN)(B3S)(BAL)(PPN)K(NH2)",
     "XDHPX",
 ]
 

--- a/tests/example_inputs.py
+++ b/tests/example_inputs.py
@@ -1,4 +1,4 @@
-example_ligangs = [
+example_ligands = [
     "C",
     "O",
     "C(C1C(C(C(C(O1)O)O)O)O)O",

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,25 @@
+from chai_lab.data.parsing.input_validation import (
+    constituents_of_modified_fasta,
+    identify_potential_entity_types,
+)
+from chai_lab.data.parsing.structure.entity_type import EntityType
+
+from .example_inputs import example_dna, example_ligangs, example_proteins, example_rna
+
+
+def test_debug():
+    constituents_of_modified_fasta("[KCJ][SEP][PPN][B3S][BAL][PPN]K[NH2]")
+
+
+def test_parsing():
+    for ligand in example_ligangs:
+        assert EntityType.LIGAND in identify_potential_entity_types(ligand)
+
+    for protein in example_proteins:
+        assert EntityType.PROTEIN in identify_potential_entity_types(protein)
+
+    for dna in example_dna:
+        assert EntityType.DNA in identify_potential_entity_types(dna)
+
+    for rna in example_rna:
+        assert EntityType.RNA in identify_potential_entity_types(rna)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -14,9 +14,9 @@ def test_simple_fasta():
 
 
 def test_modified_fasta():
-    parts = constituents_of_modified_fasta("(KCJ)(SEP)(PPN)(B3S)(BAL)(PPN)K(NH2)")
+    parts = constituents_of_modified_fasta("(KCJ)(SEP)(PPN)(B3S)(BAL)(PPN)KX(NH2)")
     assert parts is not None
-    expected = ["KCJ", "SEP", "PPN", "B3S", "BAL", "PPN", "K", "NH2"]
+    expected = ["KCJ", "SEP", "PPN", "B3S", "BAL", "PPN", "K", "X", "NH2"]
     assert all([x == y for x, y in zip(parts, expected)])
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -7,8 +7,17 @@ from chai_lab.data.parsing.structure.entity_type import EntityType
 from .example_inputs import example_dna, example_ligangs, example_proteins, example_rna
 
 
-def test_debug():
-    constituents_of_modified_fasta("[KCJ][SEP][PPN][B3S][BAL][PPN]K[NH2]")
+def test_simple_fasta():
+    parts = constituents_of_modified_fasta("RKDES")
+    assert parts is not None
+    assert all(x == y for x, y in zip(parts, ["R", "K", "D", "E", "S"]))
+
+
+def test_modified_fasta():
+    parts = constituents_of_modified_fasta("(KCJ)(SEP)(PPN)(B3S)(BAL)(PPN)K(NH2)")
+    assert parts is not None
+    expected = ["KCJ", "SEP", "PPN", "B3S", "BAL", "PPN", "K", "NH2"]
+    assert all([x == y for x, y in zip(parts, expected)])
 
 
 def test_parsing():

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -7,17 +7,31 @@ from chai_lab.data.parsing.structure.entity_type import EntityType
 from .example_inputs import example_dna, example_ligands, example_proteins, example_rna
 
 
-def test_simple_fasta():
+def test_simple_protein_fasta():
     parts = constituents_of_modified_fasta("RKDES")
     assert parts is not None
     assert all(x == y for x, y in zip(parts, ["R", "K", "D", "E", "S"]))
 
 
-def test_modified_fasta():
+def test_modified_protein_fasta():
     parts = constituents_of_modified_fasta("(KCJ)(SEP)(PPN)(B3S)(BAL)(PPN)KX(NH2)")
     assert parts is not None
     expected = ["KCJ", "SEP", "PPN", "B3S", "BAL", "PPN", "K", "X", "NH2"]
-    assert all([x == y for x, y in zip(parts, expected)])
+    assert all(x == y for x, y in zip(parts, expected))
+
+
+def test_rna_fasta():
+    seq = "ACUGACG"
+    parts = constituents_of_modified_fasta(seq)
+    assert parts is not None
+    assert all(x == y for x, y in zip(parts, seq))
+
+
+def test_dna_fasta():
+    seq = "ACGACTAGCAT"
+    parts = constituents_of_modified_fasta(seq)
+    assert parts is not None
+    assert all(x == y for x, y in zip(parts, seq))
 
 
 def test_parsing():

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,7 +4,7 @@ from chai_lab.data.parsing.input_validation import (
 )
 from chai_lab.data.parsing.structure.entity_type import EntityType
 
-from .example_inputs import example_dna, example_ligangs, example_proteins, example_rna
+from .example_inputs import example_dna, example_ligands, example_proteins, example_rna
 
 
 def test_simple_fasta():
@@ -21,7 +21,7 @@ def test_modified_fasta():
 
 
 def test_parsing():
-    for ligand in example_ligangs:
+    for ligand in example_ligands:
         assert EntityType.LIGAND in identify_potential_entity_types(ligand)
 
     for protein in example_proteins:


### PR DESCRIPTION
## Description / Motivation

We observed that in many cases entities were mis-labelled (RNA/ligands/ions passed as proteins).
This adds some helpful warnings to users.

## Test plan

Some examples were added to tests
