### PR TITLE
Write predictions in cif format

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -72,7 +72,7 @@ from chai_lab.data.features.generators.token_dist_restraint import (
 from chai_lab.data.features.generators.token_pair_pocket_restraint import (
     TokenPairPocketRestraint,
 )
-from chai_lab.data.io.pdb_utils import write_pdbs_from_outputs
+from chai_lab.data.io.cif_utils import outputs_to_cif
 from chai_lab.model.diffusion_schedules import InferenceNoiseSchedule
 from chai_lab.model.utils import center_random_augmentation
 from chai_lab.ranking.frames import get_frames_and_mask
@@ -271,7 +271,7 @@ def run_inference(
         constraint_context=constraint_context,
     )
 
-    output_pdb_paths, _, _, _ = run_folding_on_context(
+    output_cif_paths, _, _, _ = run_folding_on_context(
         feature_context,
         output_dir=output_dir,
         num_trunk_recycles=num_trunk_recycles,
@@ -280,7 +280,7 @@ def run_inference(
         device=device,
     )
 
-    return output_pdb_paths
+    return output_cif_paths
 
 
 def _bin_centers(min_bin: float, max_bin: float, no_bins: int) -> Tensor:
@@ -661,20 +661,20 @@ def run_folding_on_context(
         ## Write output files
         ##
 
-        pdb_out_path = output_dir.joinpath(f"pred.model_idx_{idx}.pdb")
+        cif_out_path = output_dir.joinpath(f"pred.model_idx_{idx}.cif")
 
-        print(f"Writing output to {pdb_out_path}")
+        print(f"Writing output to {cif_out_path}")
 
         # use 0-100 scale for pLDDT in pdb outputs
         scaled_plddt_scores_per_atom = 100 * plddt_scores_atom[idx : idx + 1]
 
-        write_pdbs_from_outputs(
+        outputs_to_cif(
             coords=atom_pos[idx : idx + 1],
             bfactors=scaled_plddt_scores_per_atom,
             output_batch=move_data_to_device(inputs, torch.device("cpu")),
-            write_path=pdb_out_path,
+            write_path=cif_out_path,
         )
-        output_paths.append(pdb_out_path)
+        output_paths.append(cif_out_path)
 
         scores_basename = f"scores.model_idx_{idx}.npz"
         scores_out_path = output_dir / scores_basename

--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -673,6 +673,10 @@ def run_folding_on_context(
             bfactors=scaled_plddt_scores_per_atom,
             output_batch=move_data_to_device(inputs, torch.device("cpu")),
             write_path=cif_out_path,
+            entity_names={
+                c.entity_data.entity_id: c.entity_data.entity_name
+                for c in feature_context.chains
+            },
         )
         output_paths.append(cif_out_path)
 

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 class Input:
     sequence: str
     entity_type: int
+    identifier: str
 
 
 def get_lig_residues(
@@ -131,7 +132,7 @@ def raw_inputs_to_entitites_data(
                 release_datetime=datetime.now(),
                 pdb_id=identifier,
                 source_pdb_chain_id=_synth_subchain_id(i),
-                entity_name=f"entity_{i}_{entity_type.name}",
+                entity_name=input.identifier,
                 entity_id=entity_id,
                 method="none",
                 entity_type=entity_type,
@@ -204,6 +205,8 @@ def read_inputs(fasta_file: str | Path, length_limit: int | None = None) -> list
         logger.info(f"[fasta] [{fasta_file}] {desc} {len(sequence)}")
         # get the type of the sequence
         entity_str = desc.split("|")[0].strip().lower()
+        entity_name = desc.split("|")[1].strip().lower()
+
         match entity_str:
             case "protein":
                 entity_type = EntityType.PROTEIN
@@ -225,7 +228,7 @@ def read_inputs(fasta_file: str | Path, length_limit: int | None = None) -> list
                 f"Provided {sequence=} is likely {types_fmt}, not {entity_type.name}"
             )
 
-        retval.append(Input(sequence, entity_type.value))
+        retval.append(Input(sequence, entity_type.value, entity_name))
         total_length += len(sequence)
 
     if length_limit is not None and total_length > length_limit:

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class Input:
     sequence: str
     entity_type: int
-    identifier: str
+    entity_name: str
 
 
 def get_lig_residues(
@@ -132,7 +132,7 @@ def raw_inputs_to_entitites_data(
                 release_datetime=datetime.now(),
                 pdb_id=identifier,
                 source_pdb_chain_id=_synth_subchain_id(i),
-                entity_name=input.identifier,
+                entity_name=input.entity_name,
                 entity_id=entity_id,
                 method="none",
                 entity_type=entity_type,

--- a/chai_lab/data/io/cif_utils.py
+++ b/chai_lab/data/io/cif_utils.py
@@ -1,0 +1,196 @@
+import logging
+from pathlib import Path
+
+import modelcif
+import torch
+from ihm import ChemComp, DNAChemComp, LPeptideChemComp, RNAChemComp
+from modelcif import Assembly, AsymUnit, Entity, dumper, model
+from torch import Tensor
+
+from chai_lab.data.io.pdb_utils import (
+    PDBContext,
+    entity_to_pdb_atoms,
+    get_pdb_chain_name,
+    pdb_context_from_batch,
+)
+from chai_lab.data.parsing.structure.entity_type import EntityType
+from chai_lab.data.residue_constants import restype_3to1
+from chai_lab.utils.typing import Float
+
+logger = logging.getLogger(__name__)
+
+
+class _LocalPLDDT(modelcif.qa_metric.Local, modelcif.qa_metric.PLDDT):
+    name = "pLDDT"
+    software = None
+    description = "Predicted lddt"
+
+
+def token_centre_plddts(
+    context: PDBContext,
+    asym_id: int,
+) -> tuple[list[float], list[int]]:
+    assert context.atom_bfactor_or_plddt is not None
+    mask = context.token_asym_id == asym_id
+
+    atom_idces = context.token_centre_atom_index[mask]
+
+    # residue indices for tokens
+    residue_indices = context.token_residue_index[mask]
+
+    return context.atom_bfactor_or_plddt[atom_idces].tolist(), residue_indices.tolist()
+
+
+def get_chains_metadata(context: PDBContext) -> list[dict]:
+    # for each chain, get chain id, entity id, full sequence
+    token_res_names = context.token_res_names_to_string
+
+    records = []
+
+    for asym_id in torch.unique(context.token_asym_id):
+        if asym_id == 0:  # padding
+            continue
+
+        token_indices = torch.where(context.token_asym_id == asym_id)[0]
+        chain_token_res_names = [token_res_names[i] for i in token_indices]
+
+        residue_indices = context.token_residue_index[token_indices]
+
+        # check no missing residues
+        max_res = torch.max(residue_indices).item()
+        tokens_in_residue = residue_indices[..., None] == torch.arange(max_res + 1)
+        assert tokens_in_residue.any(dim=-1).all()
+
+        _, inverse = torch.unique(residue_indices, return_inverse=True)
+        first_token_in_resi = torch.unique(inverse).tolist()
+
+        sequence = [chain_token_res_names[i] for i in first_token_in_resi]
+        entity_id = context.token_entity_id[token_indices][0]
+
+        entity_type: int = context.get_chain_entity_type(asym_id)
+
+        records.append(
+            {
+                "sequence": sequence,
+                "entity_id": entity_id.item(),
+                "asym_id": asym_id.item(),
+                "entity_type": entity_type,
+            }
+        )
+
+    return records
+
+
+def _to_chem_component(res_name_3: str, entity_type: int):
+    match entity_type:
+        case EntityType.LIGAND.value:
+            code = res_name_3
+            return ChemComp(res_name_3, code, code_canonical=code)
+        case EntityType.PROTEIN.value:
+            code = restype_3to1.get(res_name_3, res_name_3)
+            return LPeptideChemComp(res_name_3, code, code_canonical=code)
+        case EntityType.DNA.value:
+            code = res_name_3
+            # canonical code is DA -> A for DNA in cif files from wwpdb
+            return DNAChemComp(res_name_3, code, code_canonical=code[-1])
+        case EntityType.RNA.value:
+            code = res_name_3
+            return RNAChemComp(res_name_3, code, code_canonical=code)
+        case _:
+            raise NotImplementedError
+
+
+def sequence_to_chem_comps(sequence: list[str], entity_type: int) -> list[ChemComp]:
+    return [_to_chem_component(resi, entity_type) for resi in sequence]
+
+
+def context_to_cif(context: PDBContext, outpath: Path):
+    records = get_chains_metadata(context)
+
+    entities_map = {}
+    for record in records:
+        entity_id = record["entity_id"]
+        if entity_id in entities_map:
+            continue
+
+        chem_components = sequence_to_chem_comps(
+            record["sequence"], record["entity_type"]
+        )
+        cif_entity = Entity(chem_components, description=f"Entity {entity_id}")
+
+        entities_map[entity_id] = cif_entity
+
+    chains_map = {}
+
+    def _make_chain(record: dict) -> AsymUnit:
+        asym_id = record["asym_id"]
+        chain_id_str = get_pdb_chain_name(asym_id)
+        entity_id = record["entity_id"]
+
+        return AsymUnit(
+            entities_map[entity_id],
+            details=f"Chain {chain_id_str}",
+            id=chain_id_str,
+        )
+
+    chains_map = {r["asym_id"]: _make_chain(r) for r in records}
+
+    pdb_atoms: list[list] = entity_to_pdb_atoms(context)
+
+    _assembly = Assembly(chains_map.values(), name="Assembly 1")
+
+    class PredModel(model.AbInitioModel):
+        def get_atoms(self):
+            for atoms_list in pdb_atoms:
+                for a in atoms_list:
+                    yield model.Atom(
+                        asym_unit=chains_map[a.asym_id],
+                        type_symbol=a.element,
+                        seq_id=int(a.residue_index),
+                        atom_id=a.atom_name,
+                        x=a.pos[0],
+                        y=a.pos[1],
+                        z=a.pos[2],
+                        het=False,
+                        biso=a.b_factor,
+                        occupancy=1.00,
+                    )
+
+    _model = PredModel(_assembly, name="pred_model_1")
+
+    for asym_id, cif_asym_unit in chains_map.items():
+        entity_type = context.get_chain_entity_type(asym_id)
+
+        if entity_type != EntityType.LIGAND.value:
+            # token centres are Ca or C1' for nucleic acids
+            chain_plddts, residue_indices = token_centre_plddts(
+                context,
+                asym_id,
+            )
+
+            for residue_idx, plddt in zip(
+                residue_indices,
+                chain_plddts,
+            ):
+                _model.qa_metrics.append(
+                    _LocalPLDDT(cif_asym_unit.residue(residue_idx + 1), plddt)
+                )
+
+    system = modelcif.System(title="Chai-1 predicted structure")
+    system.authors = ["Chai team"]
+    model_group = model.ModelGroup([_model], name="pred")
+    system.model_groups.append(model_group)
+
+    dumper.write(open(outpath, "w"), systems=[system])
+
+
+def outputs_to_cif(
+    coords: Float[Tensor, "1 n_atoms 3"],
+    output_batch: dict,
+    write_path: Path,
+    bfactors: Float[Tensor, "1 n_atoms"] | None = None,
+):
+    context = pdb_context_from_batch(output_batch, coords, plddt=bfactors)
+    write_path.parent.mkdir(parents=True, exist_ok=True)
+    context_to_cif(context, write_path)
+    logger.info(f"saved cif file to {write_path}")

--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -147,7 +147,7 @@ class PDBContext:
         atom_residue_index = (
             self.token_residue_index[self.atom_token_index] + 1
         )  # residues are 1-indexed
-        atom_names = _tensor_to_atom_names(self.atom_ref_name_chars.unsqueeze(0))
+        atom_names = _tensor_to_atom_names(self.atom_ref_name_chars)
         atom_res_names = self.token_residue_names[self.atom_token_index]
         atom_res_names_strs = [
             tensorcode_to_string(x)[:3].ljust(3) for x in atom_res_names
@@ -184,14 +184,6 @@ class PDBContext:
             )
             pdb_atoms.append(atom)
         return pdb_atoms
-
-    # @classmethod
-    # def cat(cls, contexts: list["PDBContext"]) -> "PDBContext":
-    #     """Concatenates multiple posebuster contexts into a single context"""
-    #     cat_attrs: dict[str, Tensor] = dict()
-    #     for attr in cls.__annotations__.keys():
-    #         cat_attrs[attr] = torch.cat([getattr(c, attr) for c in contexts], dim=0)
-    #     return cls(**cat_attrs)
 
 
 def _atomic_num_to_element(atomic_num: int) -> str:
@@ -276,5 +268,5 @@ def _tensor_to_atom_names(
 ) -> list[str]:
     return [
         "".join([chr(ord_val + 32) for ord_val in ords_atom]).rstrip()
-        for ords_atom in tensor.squeeze(0)
+        for ords_atom in tensor
     ]

--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -15,6 +15,15 @@ from chai_lab.utils.typing import Bool, Float, Int, UInt8, typecheck
 logger = logging.getLogger(__name__)
 
 
+_CHAIN_VOCAB = string.ascii_uppercase + string.ascii_lowercase
+
+
+def get_pdb_chain_name(asym_id: int) -> str:
+    if asym_id >= len(_CHAIN_VOCAB):
+        logger.warning(f"Too many chains for PDB file: {asym_id} -- wrapping around")
+    return _CHAIN_VOCAB[(asym_id - 1) % len(_CHAIN_VOCAB)]  # 1 -> A
+
+
 @dataclass(frozen=True)
 class PDBAtom:
     record_type: str
@@ -23,6 +32,7 @@ class PDBAtom:
     alt_loc: str
     res_name_3: str
     chain_tag: str
+    asym_id: int
     residue_index: int
     insertion_code: str
     pos: list[float]
@@ -45,6 +55,24 @@ class PDBAtom:
         )
         return atom_line
 
+    def rename(self, atom_name: str) -> "PDBAtom":
+        return PDBAtom(
+            self.record_type,
+            self.atom_index,
+            atom_name,
+            self.alt_loc,
+            self.res_name_3,
+            self.chain_tag,
+            self.asym_id,
+            self.residue_index,
+            self.insertion_code,
+            self.pos,
+            self.occupancy,
+            self.b_factor,
+            self.element,
+            self.charge,
+        )
+
 
 def write_pdb(chain_atoms: list[list[PDBAtom]], out_path: str):
     with open(out_path, "w") as f:
@@ -63,13 +91,17 @@ class PDBContext:
     token_residue_index: Int[Tensor, "n_tokens"]
     token_asym_id: Int[Tensor, "n_tokens"]
     token_entity_type: Int[Tensor, "n_tokens"]
+    token_entity_id: Int[Tensor, "n_tokens"]
     token_residue_names: UInt8[Tensor, "n_tokens 8"]
+    token_centre_atom_index: Int[Tensor, "n_tokens"]
     atom_token_index: Int[Tensor, "n_atoms"]
     atom_ref_element: Int[Tensor, "n_atoms"]
     atom_ref_mask: Bool[Tensor, "n_atoms"]
     atom_coords: Float[Tensor, "n_atoms 3"]
     atom_exists_mask: Bool[Tensor, "n_atoms"]
+    token_exists_mask: Bool[Tensor, "n_tokens"]
     atom_ref_name_chars: Int[Tensor, "n_atoms 4"]
+    atom_within_token_index: Int[Tensor, "n_atoms"]
     atom_bfactor_or_plddt: Float[Tensor, "n_atoms"] | None = None
 
     @cached_property
@@ -95,6 +127,13 @@ class PDBContext:
     def is_entity(self, ety: EntityType) -> bool:
         return self.token_entity_type[0].item() == ety.value
 
+    def get_chain_entity_type(self, asym_id: int) -> int:
+        mask = self.token_asym_id == asym_id
+        assert mask.sum() > 0
+        e_type = self.token_entity_type[mask][0].item()
+        assert isinstance(e_type, int)
+        return e_type
+
     def get_pdb_atoms(self):
         # warning: calling this on cuda tensors is extremely slow
         atom_asym_id = self.token_asym_id[self.atom_token_index]
@@ -117,20 +156,14 @@ class PDBContext:
                 # skip missing atoms
                 continue
 
-            chain_tag_vocab = string.ascii_uppercase + string.ascii_lowercase
-            if int(atom_asym_id[atom_index].item()) >= len(chain_tag_vocab):
-                logger.warning(
-                    f"Too many chains for PDB file: {atom_asym_id[atom_index].item()} -- wrapping around"
-                )
             atom = PDBAtom(
                 record_type="ATOM" if not self.is_ligand else "HETATM",
                 atom_index=atom_index,
                 atom_name=atom_names[atom_index],
                 alt_loc="",
                 res_name_3=atom_res_names_strs[atom_index],
-                chain_tag=chain_tag_vocab[
-                    int(atom_asym_id[atom_index].item()) % len(chain_tag_vocab)
-                ],
+                chain_tag=get_pdb_chain_name(int(atom_asym_id[atom_index].item())),
+                asym_id=int(atom_asym_id[atom_index].item()),
                 residue_index=int(atom_residue_index[atom_index].item()),
                 insertion_code="",
                 pos=self.atom_coords[atom_index].tolist(),
@@ -164,8 +197,26 @@ def entity_to_pdb_atoms(entity: PDBContext) -> list[list[PDBAtom]]:
     pdb_atoms = entity.get_pdb_atoms()
     chains = defaultdict(list)
     for atom in pdb_atoms:
-        chains[atom.chain_tag].append(atom)
+        chains[atom.asym_id].append(atom)
+
+    for asym_id in chains:
+        # deduplicate atom names within all ligand chains
+        if entity.get_chain_entity_type(asym_id) == EntityType.LIGAND.value:
+            chains[asym_id] = rename_ligand_atoms(chains[asym_id])
+
     return list(chains.values())
+
+
+def rename_ligand_atoms(atoms: list[PDBAtom]) -> list[PDBAtom]:
+    # transform ligand atom names from "C" to "C1", "C2"...
+    atom_type_counter: dict[str, int] = {}
+    renumbered_atoms = []
+    for atom in atoms:
+        idx = atom_type_counter.get(atom.element, 1)
+        atom_type_counter[atom.element] = idx + 1
+        base_name = atom.atom_name
+        renumbered_atoms.append(atom.rename(f"{base_name}_{idx}"))
+    return renumbered_atoms
 
 
 def entities_to_pdb_file(entities: list[PDBContext], path: str):
@@ -182,14 +233,18 @@ def pdb_context_from_batch(
         token_residue_index=d["token_residue_index"][0],
         token_asym_id=d["token_asym_id"][0],
         token_entity_type=d["token_entity_type"][0],
+        token_entity_id=d["token_entity_id"][0],
         token_residue_names=d["token_residue_name"][0],
+        token_centre_atom_index=d["token_centre_atom_index"][0],
         atom_token_index=d["atom_token_index"][0],
         atom_ref_element=d["atom_ref_element"][0],
         atom_ref_mask=d["atom_ref_mask"][0],
         atom_coords=coords[0],
         atom_exists_mask=d["atom_exists_mask"][0],
+        token_exists_mask=d["token_exists_mask"][0],
         atom_ref_name_chars=d["atom_ref_name_chars"][0],
         atom_bfactor_or_plddt=plddt[0] if plddt is not None else None,
+        atom_within_token_index=d["atom_within_token_index"][0],
     )
 
 

--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -92,7 +92,7 @@ def write_pdb(chain_atoms: list[list[PDBAtom]], out_path: str):
 @typecheck
 @dataclass
 class PDBContext:
-    """Data needed to produce Posebuster input file types"""
+    """Complex (multiple entities) represented as a collection of tensors"""
 
     token_residue_index: Int[Tensor, "n_tokens"]
     token_asym_id: Int[Tensor, "n_tokens"]
@@ -145,7 +145,8 @@ class PDBContext:
         ]
 
         pdb_atoms = []
-        for atom_index in range(self.num_atoms):
+        num_atoms = self.atom_coords.shape[0]
+        for atom_index in range(num_atoms):
             if not self.atom_exists_mask[atom_index].item():
                 # skip missing atoms
                 continue

--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -115,20 +115,8 @@ class PDBContext:
         return [tensorcode_to_string(x) for x in self.token_residue_names.cpu()]
 
     @property
-    def num_atoms(self) -> int:
-        return self.atom_coords.shape[0]
-
-    @property
-    def is_protein(self) -> bool:
-        return self.is_entity(EntityType.PROTEIN)
-
-    @property
     def is_ligand(self) -> bool:
         return self.is_entity(EntityType.LIGAND)
-
-    @property
-    def first_residue_name(self) -> str:
-        return self.token_res_names_to_string[0].strip()
 
     def is_entity(self, ety: EntityType) -> bool:
         return self.token_entity_type[0].item() == ety.value

--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -19,9 +19,15 @@ _CHAIN_VOCAB = string.ascii_uppercase + string.ascii_lowercase
 
 
 def get_pdb_chain_name(asym_id: int) -> str:
-    if asym_id >= len(_CHAIN_VOCAB):
-        logger.warning(f"Too many chains for PDB file: {asym_id} -- wrapping around")
-    return _CHAIN_VOCAB[(asym_id - 1) % len(_CHAIN_VOCAB)]  # 1 -> A
+    vocab_index = asym_id - 1  # 1 -> A
+    if vocab_index >= len(_CHAIN_VOCAB):
+        # two letter codes
+        chr1, chr2 = (
+            (vocab_index // len(_CHAIN_VOCAB)) - 1,
+            vocab_index % len(_CHAIN_VOCAB),
+        )
+        return _CHAIN_VOCAB[chr1] + _CHAIN_VOCAB[chr2]
+    return _CHAIN_VOCAB[vocab_index]
 
 
 @dataclass(frozen=True)

--- a/chai_lab/data/residue_constants.py
+++ b/chai_lab/data/residue_constants.py
@@ -595,3 +595,5 @@ restype_1to3 = {
 }
 
 restype_1to3_with_x = {**restype_1to3, "X": "UNK"}
+
+restype_3to1 = {v: k for k, v in restype_1to3.items()}

--- a/examples/predict_structure.py
+++ b/examples/predict_structure.py
@@ -24,7 +24,7 @@ fasta_path = Path("/tmp/example.fasta")
 fasta_path.write_text(example_fasta)
 
 output_dir = Path("/tmp/outputs")
-output_pdb_paths = run_inference(
+output_cif_paths = run_inference(
     fasta_file=fasta_path,
     output_dir=output_dir,
     # 'default' setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ module = [
     "DockQ.*",
     "boto3.*",
     "transformers.*",
+    "modelcif.*",
+    "ihm.*",
 ]
 ignore_missing_imports = true
 

--- a/requirements.in
+++ b/requirements.in
@@ -29,6 +29,7 @@ rdkit==2023.9.5    # parsing of ligands. 2023.9.6 has broken type stubs
 biopython==1.83    # parsing, data access
 antipickle==0.2.0  # save/load heterogeneous python structures
 tmtools>=0.0.3     # Python bindings for the TM-align algorithm
+modelcif           # mmcif writing
 
 # commented out following optional dependencies for release on pypi
 # dockq metric for comparing predicted pdbs and ground truth pdbs

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ rdkit==2023.9.5    # parsing of ligands. 2023.9.6 has broken type stubs
 biopython==1.83    # parsing, data access
 antipickle==0.2.0  # save/load heterogeneous python structures
 tmtools>=0.0.3     # Python bindings for the TM-align algorithm
-modelcif           # mmcif writing
+modelcif>=1.0      # mmcif writing, confirmed to work currently latest 1.0
 
 # commented out following optional dependencies for release on pypi
 # dockq metric for comparing predicted pdbs and ground truth pdbs


### PR DESCRIPTION
## Description

- Switch output file format from PDB to CIF
- Use fasta headers as entity descriptions in output CIF files
- Add the following under LocalLDDT qa_metric:  C\alpha LDDT for proteins, C1' LDDT for nucleic acids
- Keep a per-atom LDDT under B-factor column as the ligand LDDT computed per-atom is more informative than the average over the ligand. Per-atom metrics can't be written as "Local" quality assessment metrics in python-modelcif API (https://python-modelcif.readthedocs.io/en/latest/qa_metric.html#modelcif.qa_metric.Local) 

## Test plan

Tested on a diversity of inputs: proteins, modified residues, DNA, RNA, ligand, complexes and multiple chains from same entity.
