### PR TITLE
Remove OXT atom in non-standard residues

### DIFF
--- a/chai_lab/utils/paths.py
+++ b/chai_lab/utils/paths.py
@@ -50,8 +50,8 @@ class Downloadable:
 
 
 cached_conformers = Downloadable(
-    url="https://chaiassets.com/chai1-inference-depencencies/conformers.apkl",
-    path=downloads_path.joinpath("conformers.apkl"),
+    url="https://chaiassets.com/chai1-inference-depencencies/conformers_v1.apkl",
+    path=downloads_path.joinpath("conformers_v1.apkl"),
 )
 
 


### PR DESCRIPTION
## Description

Predict correct backbones for non-standard protein residues, by removing OXT from the set of predicted atoms. 

## Motivation

Fix #56 

## Test plan

Tested locally with PTR, SEP, TPO, ALY. 
<img width="411" alt="image" src="https://github.com/user-attachments/assets/fe80642a-174e-4993-85d3-8b2a964a9222">

