### PR TITLE
add pre-commit to verify license headers in python files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,24 @@ repos:
         args:
           - "--template"
           - |
-            Copyright (c) 2024 Chai Discovery, Inc.
-
+            Copyright (c) [YEARS] Chai Discovery, Inc.
             This source code is licensed under the Chai Discovery Community License
             Agreement (LICENSE.md) found in the root directory of this source tree.
           # - "--owner=The Pre-Commit License Headers Authors"
+        include: .*py
+        exclude: |
+          (?x)^(
+            examples/.*|
+            .pre-commit-config.yaml|
+            .pre-commit-hooks.yaml|
+            .github/workflows/.*yml|
+            .github/dependabot.yml|
+            .github/pull_request_template.md|
+            Dockerfile.chailab|
+            LICENSE.md|
+            README.md|
+            requirements.in|
+            ruff.toml|
+            chai_lab/data/residue_constants.py|
+            pyproject.toml
+          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,16 @@ repos:
       - id: ruff
       # Run the formatter.
       - id: ruff-format
+
+  - repo: https://github.com/johannsdg/pre-commit-license-headers
+    rev: v0.1.0
+    hooks:
+      - id: check-license-headers
+        args:
+          - "--template"
+          - |
+            Copyright (c) 2024 Chai Discovery, Inc.
+
+            This source code is licensed under the Chai Discovery Community License
+            Agreement (LICENSE.md) found in the root directory of this source tree.
+          # - "--owner=The Pre-Commit License Headers Authors"

--- a/chai_lab/__init__.py
+++ b/chai_lab/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 __version__ = "0.0.1"

--- a/chai_lab/__init__.py
+++ b/chai_lab/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 __version__ = "0.0.1"

--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -1,4 +1,8 @@
-# %%
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
+
+
 import math
 from collections import Counter
 from dataclasses import dataclass

--- a/chai_lab/data/__init__.py
+++ b/chai_lab/data/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/collate/__init__.py
+++ b/chai_lab/data/collate/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/collate/__init__.py
+++ b/chai_lab/data/collate/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/collate/collate.py
+++ b/chai_lab/data/collate/collate.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import dataclasses
 import logging
 from typing import Any

--- a/chai_lab/data/collate/collate.py
+++ b/chai_lab/data/collate/collate.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import dataclasses
 import logging
 from typing import Any

--- a/chai_lab/data/collate/utils.py
+++ b/chai_lab/data/collate/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 from chai_lab.data.dataset.structure.all_atom_structure_context import (

--- a/chai_lab/data/collate/utils.py
+++ b/chai_lab/data/collate/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 from chai_lab.data.dataset.structure.all_atom_structure_context import (

--- a/chai_lab/data/dataset/__init__.py
+++ b/chai_lab/data/dataset/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/dataset/__init__.py
+++ b/chai_lab/data/dataset/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/dataset/all_atom_feature_context.py
+++ b/chai_lab/data/dataset/all_atom_feature_context.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from dataclasses import dataclass
 from typing import Any, Final

--- a/chai_lab/data/dataset/all_atom_feature_context.py
+++ b/chai_lab/data/dataset/all_atom_feature_context.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from dataclasses import dataclass
 from typing import Any, Final

--- a/chai_lab/data/dataset/constraints/__init__.py
+++ b/chai_lab/data/dataset/constraints/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/dataset/constraints/__init__.py
+++ b/chai_lab/data/dataset/constraints/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/dataset/constraints/constraint_context.py
+++ b/chai_lab/data/dataset/constraints/constraint_context.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import asdict, dataclass
 from typing import Any
 

--- a/chai_lab/data/dataset/constraints/constraint_context.py
+++ b/chai_lab/data/dataset/constraints/constraint_context.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import asdict, dataclass
 from typing import Any
 

--- a/chai_lab/data/dataset/embeddings/__init__.py
+++ b/chai_lab/data/dataset/embeddings/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/dataset/embeddings/__init__.py
+++ b/chai_lab/data/dataset/embeddings/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/dataset/embeddings/embedding_context.py
+++ b/chai_lab/data/dataset/embeddings/embedding_context.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import asdict, dataclass
 
 import torch

--- a/chai_lab/data/dataset/embeddings/embedding_context.py
+++ b/chai_lab/data/dataset/embeddings/embedding_context.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import asdict, dataclass
 
 import torch

--- a/chai_lab/data/dataset/embeddings/esm.py
+++ b/chai_lab/data/dataset/embeddings/esm.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import os
 from contextlib import contextmanager
 

--- a/chai_lab/data/dataset/embeddings/esm.py
+++ b/chai_lab/data/dataset/embeddings/esm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import os
 from contextlib import contextmanager
 

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 import string
 from dataclasses import dataclass

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 import string
 from dataclasses import dataclass

--- a/chai_lab/data/dataset/msas/__init__.py
+++ b/chai_lab/data/dataset/msas/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/dataset/msas/__init__.py
+++ b/chai_lab/data/dataset/msas/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/dataset/msas/msa_context.py
+++ b/chai_lab/data/dataset/msas/msa_context.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 import torch

--- a/chai_lab/data/dataset/msas/msa_context.py
+++ b/chai_lab/data/dataset/msas/msa_context.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 import torch

--- a/chai_lab/data/dataset/structure/all_atom_residue_tokenizer.py
+++ b/chai_lab/data/dataset/structure/all_atom_residue_tokenizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from dataclasses import dataclass
 from itertools import chain

--- a/chai_lab/data/dataset/structure/all_atom_residue_tokenizer.py
+++ b/chai_lab/data/dataset/structure/all_atom_residue_tokenizer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from dataclasses import dataclass
 from itertools import chain

--- a/chai_lab/data/dataset/structure/all_atom_structure_context.py
+++ b/chai_lab/data/dataset/structure/all_atom_structure_context.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from dataclasses import asdict, dataclass
 from functools import cached_property, partial

--- a/chai_lab/data/dataset/structure/all_atom_structure_context.py
+++ b/chai_lab/data/dataset/structure/all_atom_structure_context.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from dataclasses import asdict, dataclass
 from functools import cached_property, partial

--- a/chai_lab/data/dataset/structure/chain.py
+++ b/chai_lab/data/dataset/structure/chain.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 from chai_lab.data.dataset.structure.all_atom_structure_context import (

--- a/chai_lab/data/dataset/structure/chain.py
+++ b/chai_lab/data/dataset/structure/chain.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 from chai_lab.data.dataset.structure.all_atom_structure_context import (

--- a/chai_lab/data/dataset/structure/utils.py
+++ b/chai_lab/data/dataset/structure/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from functools import lru_cache
 
 import torch

--- a/chai_lab/data/dataset/structure/utils.py
+++ b/chai_lab/data/dataset/structure/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from functools import lru_cache
 
 import torch

--- a/chai_lab/data/dataset/templates/context.py
+++ b/chai_lab/data/dataset/templates/context.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from dataclasses import asdict, dataclass
 

--- a/chai_lab/data/dataset/templates/context.py
+++ b/chai_lab/data/dataset/templates/context.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from dataclasses import asdict, dataclass
 

--- a/chai_lab/data/features/__init__.py
+++ b/chai_lab/data/features/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/features/__init__.py
+++ b/chai_lab/data/features/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/features/feature_factory.py
+++ b/chai_lab/data/features/feature_factory.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 """Helper methods for generating model input features"""
 
 import logging

--- a/chai_lab/data/features/feature_factory.py
+++ b/chai_lab/data/features/feature_factory.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 """Helper methods for generating model input features"""
 
 import logging

--- a/chai_lab/data/features/feature_type.py
+++ b/chai_lab/data/features/feature_type.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from enum import Enum
 
 

--- a/chai_lab/data/features/feature_type.py
+++ b/chai_lab/data/features/feature_type.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from enum import Enum
 
 

--- a/chai_lab/data/features/feature_utils.py
+++ b/chai_lab/data/features/feature_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 """Utility classes and functions for feature representations"""
 
 from chai_lab.utils.typing import typecheck

--- a/chai_lab/data/features/feature_utils.py
+++ b/chai_lab/data/features/feature_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 """Utility classes and functions for feature representations"""
 
 from chai_lab.utils.typing import typecheck

--- a/chai_lab/data/features/generators/__init__.py
+++ b/chai_lab/data/features/generators/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/features/generators/__init__.py
+++ b/chai_lab/data/features/generators/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/features/generators/atom_element.py
+++ b/chai_lab/data/features/generators/atom_element.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from torch import Tensor
 

--- a/chai_lab/data/features/generators/atom_element.py
+++ b/chai_lab/data/features/generators/atom_element.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from torch import Tensor
 

--- a/chai_lab/data/features/generators/atom_name.py
+++ b/chai_lab/data/features/generators/atom_name.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from torch import Tensor
 
 from chai_lab.data.features.feature_type import FeatureType

--- a/chai_lab/data/features/generators/atom_name.py
+++ b/chai_lab/data/features/generators/atom_name.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from torch import Tensor
 
 from chai_lab.data.features.feature_type import FeatureType

--- a/chai_lab/data/features/generators/base.py
+++ b/chai_lab/data/features/generators/base.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 """Feature Generator ABC and Default implementation"""
 
 from abc import ABC

--- a/chai_lab/data/features/generators/base.py
+++ b/chai_lab/data/features/generators/base.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 """Feature Generator ABC and Default implementation"""
 
 from abc import ABC

--- a/chai_lab/data/features/generators/blocked_atom_pair_distances.py
+++ b/chai_lab/data/features/generators/blocked_atom_pair_distances.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from typing import Any, Literal
 
 import torch

--- a/chai_lab/data/features/generators/blocked_atom_pair_distances.py
+++ b/chai_lab/data/features/generators/blocked_atom_pair_distances.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from typing import Any, Literal
 
 import torch

--- a/chai_lab/data/features/generators/docking.py
+++ b/chai_lab/data/features/generators/docking.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 import random
 from dataclasses import dataclass

--- a/chai_lab/data/features/generators/docking.py
+++ b/chai_lab/data/features/generators/docking.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 import random
 from dataclasses import dataclass

--- a/chai_lab/data/features/generators/esm_generator.py
+++ b/chai_lab/data/features/generators/esm_generator.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from torch import Tensor
 
 from chai_lab.data.features.feature_type import FeatureType

--- a/chai_lab/data/features/generators/esm_generator.py
+++ b/chai_lab/data/features/generators/esm_generator.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from torch import Tensor
 
 from chai_lab.data.features.feature_type import FeatureType

--- a/chai_lab/data/features/generators/identity.py
+++ b/chai_lab/data/features/generators/identity.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/identity.py
+++ b/chai_lab/data/features/generators/identity.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/is_cropped_chain.py
+++ b/chai_lab/data/features/generators/is_cropped_chain.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from torch import Tensor
 

--- a/chai_lab/data/features/generators/is_cropped_chain.py
+++ b/chai_lab/data/features/generators/is_cropped_chain.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from torch import Tensor
 

--- a/chai_lab/data/features/generators/missing_chain_contact.py
+++ b/chai_lab/data/features/generators/missing_chain_contact.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from torch import Tensor
 

--- a/chai_lab/data/features/generators/missing_chain_contact.py
+++ b/chai_lab/data/features/generators/missing_chain_contact.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from torch import Tensor
 

--- a/chai_lab/data/features/generators/msa.py
+++ b/chai_lab/data/features/generators/msa.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from typing import Any
 
 import torch

--- a/chai_lab/data/features/generators/msa.py
+++ b/chai_lab/data/features/generators/msa.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from typing import Any
 
 import torch

--- a/chai_lab/data/features/generators/ref_pos.py
+++ b/chai_lab/data/features/generators/ref_pos.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 
 from chai_lab.data.features.feature_type import FeatureType

--- a/chai_lab/data/features/generators/ref_pos.py
+++ b/chai_lab/data/features/generators/ref_pos.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 
 from chai_lab.data.features.feature_type import FeatureType

--- a/chai_lab/data/features/generators/relative_chain.py
+++ b/chai_lab/data/features/generators/relative_chain.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/relative_chain.py
+++ b/chai_lab/data/features/generators/relative_chain.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/relative_entity.py
+++ b/chai_lab/data/features/generators/relative_entity.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/relative_entity.py
+++ b/chai_lab/data/features/generators/relative_entity.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/relative_sep.py
+++ b/chai_lab/data/features/generators/relative_sep.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/relative_sep.py
+++ b/chai_lab/data/features/generators/relative_sep.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/relative_token.py
+++ b/chai_lab/data/features/generators/relative_token.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/relative_token.py
+++ b/chai_lab/data/features/generators/relative_token.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/data/features/generators/residue_type.py
+++ b/chai_lab/data/features/generators/residue_type.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import numpy as np
 import torch
 from torch import Tensor

--- a/chai_lab/data/features/generators/residue_type.py
+++ b/chai_lab/data/features/generators/residue_type.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import numpy as np
 import torch
 from torch import Tensor

--- a/chai_lab/data/features/generators/structure_metadata.py
+++ b/chai_lab/data/features/generators/structure_metadata.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import repeat
 from torch import Tensor

--- a/chai_lab/data/features/generators/structure_metadata.py
+++ b/chai_lab/data/features/generators/structure_metadata.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import repeat
 from torch import Tensor

--- a/chai_lab/data/features/generators/templates.py
+++ b/chai_lab/data/features/generators/templates.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 """
 Feature generators for templates. This includes the following:
 - Template mask (includes both the psuedo beta mask and backbone frame mask)

--- a/chai_lab/data/features/generators/templates.py
+++ b/chai_lab/data/features/generators/templates.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 """
 Feature generators for templates. This includes the following:
 - Template mask (includes both the psuedo beta mask and backbone frame mask)

--- a/chai_lab/data/features/generators/token_dist_restraint.py
+++ b/chai_lab/data/features/generators/token_dist_restraint.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from dataclasses import dataclass
 

--- a/chai_lab/data/features/generators/token_dist_restraint.py
+++ b/chai_lab/data/features/generators/token_dist_restraint.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from dataclasses import dataclass
 

--- a/chai_lab/data/features/generators/token_pair_distance.py
+++ b/chai_lab/data/features/generators/token_pair_distance.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from typing import Any
 
 import torch

--- a/chai_lab/data/features/generators/token_pair_distance.py
+++ b/chai_lab/data/features/generators/token_pair_distance.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from typing import Any
 
 import torch

--- a/chai_lab/data/features/generators/token_pair_pocket_restraint.py
+++ b/chai_lab/data/features/generators/token_pair_pocket_restraint.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from dataclasses import dataclass
 

--- a/chai_lab/data/features/generators/token_pair_pocket_restraint.py
+++ b/chai_lab/data/features/generators/token_pair_pocket_restraint.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from dataclasses import dataclass
 

--- a/chai_lab/data/features/token_utils.py
+++ b/chai_lab/data/features/token_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import repeat
 from torch import Tensor

--- a/chai_lab/data/features/token_utils.py
+++ b/chai_lab/data/features/token_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import repeat
 from torch import Tensor

--- a/chai_lab/data/io/__init__.py
+++ b/chai_lab/data/io/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/io/__init__.py
+++ b/chai_lab/data/io/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/io/cif_utils.py
+++ b/chai_lab/data/io/cif_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from pathlib import Path
 

--- a/chai_lab/data/io/cif_utils.py
+++ b/chai_lab/data/io/cif_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from pathlib import Path
 

--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 import string
 from collections import defaultdict

--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 import string
 from collections import defaultdict

--- a/chai_lab/data/parsing/__init__.py
+++ b/chai_lab/data/parsing/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/parsing/__init__.py
+++ b/chai_lab/data/parsing/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/parsing/fasta.py
+++ b/chai_lab/data/parsing/fasta.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from pathlib import Path
 

--- a/chai_lab/data/parsing/fasta.py
+++ b/chai_lab/data/parsing/fasta.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from pathlib import Path
 

--- a/chai_lab/data/parsing/input_validation.py
+++ b/chai_lab/data/parsing/input_validation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 """
 Simple heuristics that can help with identification of EntityType
 """

--- a/chai_lab/data/parsing/input_validation.py
+++ b/chai_lab/data/parsing/input_validation.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 """
 Simple heuristics that can help with identification of EntityType
 """

--- a/chai_lab/data/parsing/msas/__init__.py
+++ b/chai_lab/data/parsing/msas/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/parsing/msas/__init__.py
+++ b/chai_lab/data/parsing/msas/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/parsing/msas/data_source.py
+++ b/chai_lab/data/parsing/msas/data_source.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from enum import Enum
 

--- a/chai_lab/data/parsing/msas/data_source.py
+++ b/chai_lab/data/parsing/msas/data_source.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from enum import Enum
 

--- a/chai_lab/data/parsing/msas/species.py
+++ b/chai_lab/data/parsing/msas/species.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 
 logger = logging.getLogger(__name__)

--- a/chai_lab/data/parsing/msas/species.py
+++ b/chai_lab/data/parsing/msas/species.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 
 logger = logging.getLogger(__name__)

--- a/chai_lab/data/parsing/structure/__init__.py
+++ b/chai_lab/data/parsing/structure/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/data/parsing/structure/__init__.py
+++ b/chai_lab/data/parsing/structure/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/data/parsing/structure/all_atom_entity_data.py
+++ b/chai_lab/data/parsing/structure/all_atom_entity_data.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from dataclasses import dataclass
 from datetime import datetime

--- a/chai_lab/data/parsing/structure/all_atom_entity_data.py
+++ b/chai_lab/data/parsing/structure/all_atom_entity_data.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from dataclasses import dataclass
 from datetime import datetime

--- a/chai_lab/data/parsing/structure/entity_type.py
+++ b/chai_lab/data/parsing/structure/entity_type.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from enum import Enum
 

--- a/chai_lab/data/parsing/structure/entity_type.py
+++ b/chai_lab/data/parsing/structure/entity_type.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from enum import Enum
 

--- a/chai_lab/data/parsing/structure/residue.py
+++ b/chai_lab/data/parsing/structure/residue.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 import gemmi

--- a/chai_lab/data/parsing/structure/residue.py
+++ b/chai_lab/data/parsing/structure/residue.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 import gemmi

--- a/chai_lab/data/parsing/structure/sequence.py
+++ b/chai_lab/data/parsing/structure/sequence.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 
 import gemmi

--- a/chai_lab/data/parsing/structure/sequence.py
+++ b/chai_lab/data/parsing/structure/sequence.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 
 import gemmi

--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import logging
 from pathlib import Path
 

--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import logging
 from pathlib import Path
 

--- a/chai_lab/model/__init__.py
+++ b/chai_lab/model/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/model/__init__.py
+++ b/chai_lab/model/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/model/diffusion_schedules.py
+++ b/chai_lab/model/diffusion_schedules.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 import torch

--- a/chai_lab/model/diffusion_schedules.py
+++ b/chai_lab/model/diffusion_schedules.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 import torch

--- a/chai_lab/model/utils.py
+++ b/chai_lab/model/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from typing import Any
 
 import torch

--- a/chai_lab/model/utils.py
+++ b/chai_lab/model/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from typing import Any
 
 import torch

--- a/chai_lab/ranking/__init__.py
+++ b/chai_lab/ranking/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/ranking/__init__.py
+++ b/chai_lab/ranking/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/ranking/clashes.py
+++ b/chai_lab/ranking/clashes.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 import torch

--- a/chai_lab/ranking/clashes.py
+++ b/chai_lab/ranking/clashes.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 import torch

--- a/chai_lab/ranking/frames.py
+++ b/chai_lab/ranking/frames.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import rearrange, repeat
 from torch import Tensor

--- a/chai_lab/ranking/frames.py
+++ b/chai_lab/ranking/frames.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import rearrange, repeat
 from torch import Tensor

--- a/chai_lab/ranking/plddt.py
+++ b/chai_lab/ranking/plddt.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 from einops import repeat

--- a/chai_lab/ranking/plddt.py
+++ b/chai_lab/ranking/plddt.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 from einops import repeat

--- a/chai_lab/ranking/ptm.py
+++ b/chai_lab/ranking/ptm.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 import torch

--- a/chai_lab/ranking/ptm.py
+++ b/chai_lab/ranking/ptm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 import torch

--- a/chai_lab/ranking/rank.py
+++ b/chai_lab/ranking/rank.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from dataclasses import dataclass
 
 import numpy as np

--- a/chai_lab/ranking/rank.py
+++ b/chai_lab/ranking/rank.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from dataclasses import dataclass
 
 import numpy as np

--- a/chai_lab/ranking/utils.py
+++ b/chai_lab/ranking/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/ranking/utils.py
+++ b/chai_lab/ranking/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import torch
 from einops import rearrange
 from torch import Tensor

--- a/chai_lab/utils/__init__.py
+++ b/chai_lab/utils/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/chai_lab/utils/__init__.py
+++ b/chai_lab/utils/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/chai_lab/utils/defaults.py
+++ b/chai_lab/utils/defaults.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from typing import TypeVar
 
 T = TypeVar("T")

--- a/chai_lab/utils/defaults.py
+++ b/chai_lab/utils/defaults.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from typing import TypeVar
 
 T = TypeVar("T")

--- a/chai_lab/utils/dict.py
+++ b/chai_lab/utils/dict.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from typing import TypeVar
 
 K = TypeVar("K")

--- a/chai_lab/utils/dict.py
+++ b/chai_lab/utils/dict.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from typing import TypeVar
 
 K = TypeVar("K")

--- a/chai_lab/utils/paths.py
+++ b/chai_lab/utils/paths.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import dataclasses
 import os
 from pathlib import Path

--- a/chai_lab/utils/paths.py
+++ b/chai_lab/utils/paths.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import dataclasses
 import os
 from pathlib import Path

--- a/chai_lab/utils/pickle.py
+++ b/chai_lab/utils/pickle.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import antipickle
 import torch
 

--- a/chai_lab/utils/pickle.py
+++ b/chai_lab/utils/pickle.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import antipickle
 import torch
 

--- a/chai_lab/utils/plot.py
+++ b/chai_lab/utils/plot.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 """"""
 
 import logging

--- a/chai_lab/utils/plot.py
+++ b/chai_lab/utils/plot.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 """"""
 
 import logging

--- a/chai_lab/utils/tensor_utils.py
+++ b/chai_lab/utils/tensor_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import typing
 from functools import lru_cache
 from typing import TypeVar

--- a/chai_lab/utils/tensor_utils.py
+++ b/chai_lab/utils/tensor_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import typing
 from functools import lru_cache
 from typing import TypeVar

--- a/chai_lab/utils/timeout.py
+++ b/chai_lab/utils/timeout.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 """
 Timeout utility for a function, creates a new process
 

--- a/chai_lab/utils/timeout.py
+++ b/chai_lab/utils/timeout.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 """
 Timeout utility for a function, creates a new process
 

--- a/chai_lab/utils/typing.py
+++ b/chai_lab/utils/typing.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 import typing
 
 from beartype import beartype

--- a/chai_lab/utils/typing.py
+++ b/chai_lab/utils/typing.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 import typing
 
 from beartype import beartype

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+

--- a/tests/example_inputs.py
+++ b/tests/example_inputs.py
@@ -2,6 +2,7 @@
 
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 example_ligands = [
     "C",
     "O",

--- a/tests/example_inputs.py
+++ b/tests/example_inputs.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 example_ligands = [
     "C",
     "O",

--- a/tests/test_inference_dataset.py
+++ b/tests/test_inference_dataset.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 """
 Tests for inference dataset.
 """

--- a/tests/test_inference_dataset.py
+++ b/tests/test_inference_dataset.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 """
 Tests for inference dataset.
 """

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Chai Discovery, Inc.
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
+
 from chai_lab.data.parsing.input_validation import (
     constituents_of_modified_fasta,
     identify_potential_entity_types,

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# This source code is licensed under the Chai Discovery Community License
+# Agreement (LICENSE.md) found in the root directory of this source tree.
 from chai_lab.data.parsing.input_validation import (
     constituents_of_modified_fasta,
     identify_potential_entity_types,


### PR DESCRIPTION
## Description

pre-commit check will enforce lisense header, but will allow changing years if necessary.

It is a bit tricky to have additional comments e.g. in following example `#%%` us considered a part of license header, at pre-commit complains on wrong header 🤷 

```python
# Licence Line 1
# License Line 2

#%%
import numpy as np
```

