### PR TITLE
Clarify MSA documentation

### DIFF
--- a/chai_lab/data/parsing/msas/aligned_pqt.py
+++ b/chai_lab/data/parsing/msas/aligned_pqt.py
@@ -214,6 +214,7 @@ def _merge_files_in_directory(directory: str):
         dbname = file.stem.replace("_hits", "").replace("hits_", "")
         try:
             msa_src = MSADataSource(dbname)
+            logging.info(f"Found {msa_src} MSAs in {file}")
         except ValueError:
             msa_src = MSADataSource.UNIREF90
             logging.warning(
@@ -230,5 +231,7 @@ def _merge_files_in_directory(directory: str):
 
 if __name__ == "__main__":
     import typer
+
+    logging.basicConfig(level=logging.INFO)
 
     typer.run(_merge_files_in_directory)

--- a/examples/msas/README.md
+++ b/examples/msas/README.md
@@ -24,7 +24,7 @@ See the following for a toy example of what this table might look like:
 | RKSES... | uniprot         | Mus musculus | A mouse sequence from uniprot |
 | ...      |
 
-We additionally provide example code to parse `a3m` files into this format; see `merge_multi_a3m_to_aligned_dataframe` in `chai_lab/data/parsing/msas/aligned_pqt.py`. This file can also be run as a commandline script; run `python chai_lab/data/parsing/msas/aligned_pqt.py --help` for details. Note, however, that this code defaults to only parsing pairing keys based on species annotation in UniProt files; this follows the logic described in both AlphaFold3 and AlphaFold2 multimer. To specify pairing keys for different data sources, or to use something other than species as the pairing key, we encourage users to built their own parsing logic to create `.aligned.pqt` files.
+We additionally provide example code to parse `a3m` files into this format; see `merge_multi_a3m_to_aligned_dataframe` in `chai_lab/data/parsing/msas/aligned_pqt.py`. This file can also be run as a commandline script; run `python chai_lab/data/parsing/msas/aligned_pqt.py --help` for details. Note, however, that this code defaults to only parsing pairing keys based on species annotation in UniProt files; this follows the logic described in both AlphaFold3 and AlphaFold2 multimer. To specify pairing keys for different data sources, or to use something other than species as the pairing key, we encourage users to build their own parsing logic to create `.aligned.pqt` files.
 
 ### TLDR
 

--- a/examples/msas/README.md
+++ b/examples/msas/README.md
@@ -24,7 +24,7 @@ See the following for a toy example of what this table might look like:
 | RKSES... | uniprot         | Mus musculus | A mouse sequence from uniprot |
 | ...      |
 
-We additionally provide code to parse `a3m` files into this format; see `merge_multi_a3m_to_aligned_dataframe` in `chai_lab/data/parsing/msas/aligned_pqt.py`. This file can also be run as a commandline script to run ; run `python chai_lab/data/parsing/msas/aligned_pqt.py --help` for details. 
+We additionally provide example code to parse `a3m` files into this format; see `merge_multi_a3m_to_aligned_dataframe` in `chai_lab/data/parsing/msas/aligned_pqt.py`. This file can also be run as a commandline script; run `python chai_lab/data/parsing/msas/aligned_pqt.py --help` for details. Note, however, that this code defaults to only parsing pairing keys based on species annotation in UniProt files; this follows the logic described in both AlphaFold3 and AlphaFold2 multimer. To specify pairing keys for different data sources, or to use something other than species as the pairing key, we encourage users to built their own parsing logic to create `.aligned.pqt` files.
 
 ### TLDR
 


### PR DESCRIPTION
## Description
Clarify documentation for MSAs to better describe default pairing key behavior with the provided `a3m` to `aligned.pqt` logic.
