### PR TITLE
update weights

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -417,11 +417,11 @@ def run_folding_on_context(
     _, _, model_size = msa_mask.shape
     assert model_size in AVAILABLE_MODEL_SIZES
 
-    feature_embedding = load_exported("feature_embedding.pt2", device)
-    token_input_embedder = load_exported("token_embedder.pt2", device)
-    trunk = load_exported("trunk.pt2", device)
-    diffusion_module = load_exported("diffusion_module.pt2", device)
-    confidence_head = load_exported("confidence_head.pt2", device)
+    feature_embedding = load_exported("feature_embedding.pt", device)
+    token_input_embedder = load_exported("token_embedder.pt", device)
+    trunk = load_exported("trunk.pt", device)
+    diffusion_module = load_exported("diffusion_module.pt", device)
+    confidence_head = load_exported("confidence_head.pt", device)
 
     ##
     ## Run the features through the feature embedder

--- a/chai_lab/data/collate/utils.py
+++ b/chai_lab/data/collate/utils.py
@@ -10,7 +10,7 @@ from chai_lab.data.dataset.structure.all_atom_structure_context import (
 
 # static graph is exported for different n_tokens,
 #  we pad to the closest one
-AVAILABLE_MODEL_SIZES = [256, 384, 512, 768, 1024, 2048]
+AVAILABLE_MODEL_SIZES = [256, 384, 512, 768, 1024, 1536, 2048]
 
 
 @dataclass(frozen=True)

--- a/chai_lab/data/collate/utils.py
+++ b/chai_lab/data/collate/utils.py
@@ -34,5 +34,6 @@ def get_pad_sizes(contexts: list[AllAtomStructureContext]) -> PadSizes:
     max_n_atoms = max(context.num_atoms for context in contexts)
     n_atoms = 23 * n_tokens
     assert max_n_atoms <= n_atoms
+    assert n_atoms % 32 == 0
 
     return PadSizes(n_tokens=n_tokens, n_atoms=n_atoms)

--- a/chai_lab/data/features/generators/msa.py
+++ b/chai_lab/data/features/generators/msa.py
@@ -214,7 +214,6 @@ class MSADataSourceGenerator(FeatureGenerator):
     def __init__(
         self,
         num_classes: int = 6,  # chai1 : 5 classes + mask val
-        mask_value=5,
     ):
         super().__init__(
             ty=FeatureType.MSA,
@@ -223,7 +222,6 @@ class MSADataSourceGenerator(FeatureGenerator):
             num_classes=num_classes,
             mult=1,
         )
-        self.mask_value_msa = mask_value
 
     def get_input_kwargs_from_batch(self, batch: dict[str, Any]) -> dict:
         return dict(
@@ -243,8 +241,6 @@ class MSADataSourceGenerator(FeatureGenerator):
         none = msa_dataset_source_to_int[MSADataSource.NONE]
         # chai-1 specific: replace QUERY with NONE
         msa_sequence_source[msa_sequence_source.eq(query)] = none
-        # use none as masking.
-        msa_sequence_source = msa_sequence_source.masked_fill(
-            ~msa_mask, self.mask_value_msa
-        )
+        # use none for masking.
+        msa_sequence_source = msa_sequence_source.masked_fill(~msa_mask, none)
         return self.make_feature(data=msa_sequence_source.unsqueeze(-1))

--- a/chai_lab/data/parsing/msas/data_source.py
+++ b/chai_lab/data/parsing/msas/data_source.py
@@ -74,7 +74,7 @@ msa_dataset_source_to_int = {
     MSADataSource.UNIPROT_N3: 3,
     MSADataSource.UNIREF90_N3: 2,
     MSADataSource.MGNIFY_N3: 1,
-    MSADataSource.QUERY: 5,  # TODO how does it work with chai-1?
+    MSADataSource.QUERY: 5,  # in chai-1 remapped to none.
 }
 
 database_ids: set[str] = set(x.value for x in MSADataSource)

--- a/chai_lab/utils/paths.py
+++ b/chai_lab/utils/paths.py
@@ -71,9 +71,9 @@ COMPONENT_URL = (
 def chai1_component(comp_key: str) -> Path:
     """
     Downloads exported model, stores in locally in the repo/downloads
-    comp_key: e.g. 'trunk.pt2'
+    comp_key: e.g. 'trunk.pt'
     """
-    assert comp_key.endswith(".pt2")
+    assert comp_key.endswith(".pt")
     url = COMPONENT_URL.format(comp_key=comp_key)
     result = downloads_path.joinpath("models_v2", comp_key)
     download_if_not_exists(url, result)

--- a/chai_lab/utils/paths.py
+++ b/chai_lab/utils/paths.py
@@ -63,15 +63,19 @@ cached_conformers = Downloadable(
     path=downloads_path.joinpath("conformers_v1.apkl"),
 )
 
+COMPONENT_URL = (
+    "https://chaiassets.com/chai1-inference-depencencies/models_v2/{comp_key}"
+)
+
 
 def chai1_component(comp_key: str) -> Path:
     """
     Downloads exported model, stores in locally in the repo/downloads
-    comp_key: e.g. '384/trunk.pt2'
+    comp_key: e.g. 'trunk.pt2'
     """
     assert comp_key.endswith(".pt2")
-    url = f"https://chaiassets.com/chai1-inference-depencencies/models_v2/{comp_key}"
-    result = downloads_path.joinpath("models", comp_key)
+    url = COMPONENT_URL.format(comp_key=comp_key)
+    result = downloads_path.joinpath("models_v2", comp_key)
     download_if_not_exists(url, result)
 
     return result

--- a/chai_lab/utils/paths.py
+++ b/chai_lab/utils/paths.py
@@ -70,7 +70,7 @@ def chai1_component(comp_key: str) -> Path:
     comp_key: e.g. '384/trunk.pt2'
     """
     assert comp_key.endswith(".pt2")
-    url = f"https://chaiassets.com/chai1-inference-depencencies/models/{comp_key}"
+    url = f"https://chaiassets.com/chai1-inference-depencencies/models_v2/{comp_key}"
     result = downloads_path.joinpath("models", comp_key)
     download_if_not_exists(url, result)
 


### PR DESCRIPTION
## Description / motivation

Uses single set of weights for all model sizes. Resolves some issues and warnings with previous format.

- fix #21 as now the weights are downloaded only once
- new export can run on different GPU (e.g. cuda:1), so fix #63
- I also expect that now it will work on other devices, like AMD, though didn't check. Marking x86 and apple silicon issues as fixed, though I don't expect those options to be practically viable:
   -  fix #19 
   -  fix #33 
- fix #132, (can confirm it worked on 2.5.1)

Additionally, clarifies chai-1 specific remapping of query sequence and sets correct mask value for MSA data source.

## Test plan

- checked high consistency and similar timing to previous weights.
- checked that example works and pulls new weights, checked another size
