### PR TITLE
Fix assert_never import for Python 3.10

### DIFF
--- a/chai_lab/data/parsing/restraints.py
+++ b/chai_lab/data/parsing/restraints.py
@@ -8,12 +8,12 @@ Parse table where each row correpsonds to a pairwise interaction
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import assert_never
 
 import numpy as np
 import pandas as pd
 import pandera as pa
 from pandera.typing import Series
+from typing_extensions import assert_never
 
 from chai_lab.utils.typing import typecheck
 


### PR DESCRIPTION
## Description
Import `assert_never` from `typing_extensions` rather than from `typing`

## Motivation
`assert_never` is not available in the typing module in Python 3.10. The `assert_never` function was introduced in Python 3.11 as part of the typing module

A user reported the following bug:
> After updating to the latest Chai-1 version, I encountered an error with the new file, restraints.py, `ImportError: cannot import name 'assert_never' from 'typing'`
> This suggests that upgrading to Python 3.11 might be necessary (despite pyproject.toml indicating 3.10) for using restraints.