### PR TITLE
use python3.10 shipped with ubuntu22.04

### DIFF
--- a/Dockerfile.chailab
+++ b/Dockerfile.chailab
@@ -33,6 +33,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
   # text editors, needed by git cli
   nano vim \
   build-essential libstdc++6 \
+  # python
+  python3.10 python3.10-dev \
   # (run continues)
   # stop git from complaining about dubious ownership.
   && git config --global --add safe.directory "*" \
@@ -49,7 +51,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 ENV \
   # expose CUDA libraries. Now that we don't build anything this is likely redundant
-  LD_LIBRARY_PATH="/usr/local/cuda/lib64/stubs/:$LD_LIBRARY_PATH" \
+  LD_LIBRARY_PATH="/usr/local/cuda/lib64/stubs/:${LD_LIBRARY_PATH:-}" \
   # Set uv timeout to larger value to account for slow download time of nvidia-cudnn-cu12
   UV_HTTP_TIMEOUT=1000 \
   # where virtual env will be installed
@@ -60,13 +62,15 @@ COPY ./requirements.in /tmp/requirements.in
 # from https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
 # a trick to have virtualenv "always activated"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 RUN --mount=type=cache,target=/root/.cache/uv \
   # Install uv
-  curl -LsSf https://astral.sh/uv/install.sh | sh \
-  && $HOME/.cargo/bin/uv venv --python 3.10 $VIRTUAL_ENV \
+  curl -LsSf https://astral.sh/uv/0.5.4/install.sh | sh \
+  && . $HOME/.local/bin/env \
+  && uv venv --no-python-downloads $VIRTUAL_ENV \
   # this is sh, not bash, so . not source
   && . $VIRTUAL_ENV/bin/activate \
-  && $HOME/.cargo/bin/uv pip install uv pip -r /tmp/requirements.in
+  && uv pip install uv pip -r /tmp/requirements.in
 
 
 # making sure envvars are set in all shells


### PR DESCRIPTION
- support python3.10
- astral.sh does not ship dev-headers, and thus can't install ihm afterwards, so we switch to back to ubuntu-provided python
- problem reported in https://github.com/astral-sh/uv/issues/9347 