### PR TITLE
Relax requirement for biopython

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ tqdm~=4.66
 # data import/export, application-specific
 gemmi~=0.6.3       # pdb/mmcif parsing
 rdkit==2023.9.5    # parsing of ligands. 2023.9.6 has broken type stubs
-biopython==1.83    # parsing, data access
+biopython>=1.83    # parsing, data access
 antipickle==0.2.0  # save/load heterogeneous python structures
 tmtools>=0.0.3     # Python bindings for the TM-align algorithm
 modelcif>=1.0      # mmcif writing, confirmed to work currently latest 1.0

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -2,6 +2,10 @@
 # This source code is licensed under the Chai Discovery Community License
 # Agreement (LICENSE.md) found in the root directory of this source tree.
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from chai_lab.data.parsing.fasta import read_fasta
 from chai_lab.data.parsing.input_validation import (
     constituents_of_modified_fasta,
     identify_potential_entity_types,
@@ -50,3 +54,17 @@ def test_parsing():
 
     for rna in example_rna:
         assert EntityType.RNA in identify_potential_entity_types(rna)
+
+
+def test_fasta_parsing():
+    test_string = """>foo\nRKDES\n>bar\nKEDESRRR"""
+    with TemporaryDirectory() as tmpdir:
+        fa_file = Path(tmpdir) / "test.fasta"
+        fa_file.write_text(test_string)
+        records = read_fasta(fa_file)
+
+    assert len(records) == 2
+    assert records[0].header == "foo"
+    assert records[0].sequence == "RKDES"
+    assert records[1].header == "bar"
+    assert records[1].sequence == "KEDESRRR"


### PR DESCRIPTION
## Description
Relaxes requirement for biopython to be `==1.83` to be `>=1.83`.

## Motivation
We only rely on biopython for `SeqIO` which doesn't really change its behavior; relaxed version allows better compatibility.

## Test plan
Add fasta parsing test passes.
