### PR TITLE
Fix case for homomers resulting in errors

### DIFF
--- a/chai_lab/data/dataset/msas/colabfold.py
+++ b/chai_lab/data/dataset/msas/colabfold.py
@@ -408,5 +408,7 @@ def generate_colabfold_msas(protein_seqs: list[str], msa_dir: Path):
                 ),
             )
             msa_path = msa_dir / expected_basename(protein_seq)
-            assert not msa_path.exists()
-            aligned_df.to_parquet(msa_path)
+            if not msa_path.exists():
+                # If we have a homomer, we might see the same chain multiple
+                # times. The MSAs should be identical for each.
+                aligned_df.to_parquet(msa_path)


### PR DESCRIPTION
## Description
Reduce stringency of assert checks on existing MSAs.

## Motivation
Homomers result in expected clobbering of files; handle this gracefully instead of erroring out.

## Test plan
Tested locally on an example that was previously failing.
