### PR TITLE
Cleanup cif code; properly write ligands as HETATM

### DIFF
--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -5,9 +5,10 @@
 import logging
 import string
 from collections import defaultdict
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from functools import cached_property
 from pathlib import Path
+from typing import Literal
 
 import gemmi
 from torch import Tensor
@@ -36,7 +37,7 @@ def get_pdb_chain_name(asym_id: int) -> str:
 
 @dataclass(frozen=True)
 class PDBAtom:
-    record_type: str
+    record_type: Literal["ATOM", "HETATM"]
     atom_index: int
     atom_name: str
     alt_loc: str
@@ -64,24 +65,6 @@ class PDBAtom:
             f"{self.element:>2}{self.charge:>2}"
         )
         return atom_line
-
-    def rename(self, atom_name: str) -> "PDBAtom":
-        return PDBAtom(
-            self.record_type,
-            self.atom_index,
-            atom_name,
-            self.alt_loc,
-            self.res_name_3,
-            self.chain_tag,
-            self.asym_id,
-            self.residue_index,
-            self.insertion_code,
-            self.pos,
-            self.occupancy,
-            self.b_factor,
-            self.element,
-            self.charge,
-        )
 
 
 def write_pdb(chain_atoms: list[list[PDBAtom]], out_path: str):
@@ -206,7 +189,7 @@ def rename_ligand_atoms(atoms: list[PDBAtom]) -> list[PDBAtom]:
         idx = atom_type_counter.get(atom.element, 1)
         atom_type_counter[atom.element] = idx + 1
         base_name = atom.atom_name
-        renumbered_atoms.append(atom.rename(f"{base_name}_{idx}"))
+        renumbered_atoms.append(replace(atom, atom_name=f"{base_name}_{idx}"))
     return renumbered_atoms
 
 

--- a/chai_lab/data/io/pdb_utils.py
+++ b/chai_lab/data/io/pdb_utils.py
@@ -101,13 +101,6 @@ class PDBContext:
     def token_res_names_to_string(self) -> list[str]:
         return [tensorcode_to_string(x) for x in self.token_residue_names.cpu()]
 
-    @property
-    def is_ligand(self) -> bool:
-        return self.is_entity(EntityType.LIGAND)
-
-    def is_entity(self, ety: EntityType) -> bool:
-        return self.token_entity_type[0].item() == ety.value
-
     def get_chain_entity_type(self, asym_id: int) -> int:
         mask = self.token_asym_id == asym_id
         assert mask.sum() > 0
@@ -115,7 +108,7 @@ class PDBContext:
         assert isinstance(e_type, int)
         return e_type
 
-    def get_pdb_atoms(self):
+    def get_pdb_atoms(self) -> list[PDBAtom]:
         # warning: calling this on cuda tensors is extremely slow
         atom_asym_id = self.token_asym_id[self.atom_token_index]
         # atom level attributes
@@ -131,7 +124,7 @@ class PDBContext:
             _atomic_num_to_element(int(x.item())) for x in self.atom_ref_element
         ]
 
-        pdb_atoms = []
+        pdb_atoms: list[PDBAtom] = []
         num_atoms = self.atom_coords.shape[0]
         for atom_index in range(num_atoms):
             if not self.atom_exists_mask[atom_index].item():


### PR DESCRIPTION
## Description
- Use `replace` instead of manual field reassignment for renaming
- Properly write ligands as HETATM
- Misc. cleanup

## Motivation
Some downstream analysis tools expect HETATMs for finding ligands; properly support this.

## Test plan
Tested locally, verified new format.

Here's what the new ligand cif rows look like:
```
HETATM 3116 C C_1 . LIG . 1 ? D -18.572 -5.455 5.495 1.000 4 D LIG 17.427 1
HETATM 3117 C C_2 . LIG . 1 ? D -17.844 -6.640 6.006 1.000 4 D LIG 20.338 1
HETATM 3118 C C_3 . LIG . 1 ? D -16.559 -6.269 6.652 1.000 4 D LIG 25.365 1
HETATM 3119 C C_4 . LIG . 1 ? D -15.864 -7.473 7.158 1.000 4 D LIG 27.155 1
```

Previously:
```
ATOM 3116 C C_1 . LIG . 1 ? D -18.554 -5.116 5.617 1.000 4 D LIG 19.260 1
ATOM 3117 C C_2 . LIG . 1 ? D -17.898 -6.362 6.075 1.000 4 D LIG 20.778 1
ATOM 3118 C C_3 . LIG . 1 ? D -16.598 -6.100 6.744 1.000 4 D LIG 25.843 1
ATOM 3119 C C_4 . LIG . 1 ? D -15.951 -7.366 7.155 1.000 4 D LIG 27.725 1
```
