### PR TITLE
Add CLI option to set colabfold server url

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ For example, to run the model with MSAs (which we recommend for improved perform
 chai fold --use-msa-server input.fasta output_folder
 ```
 
+If you are hosting your own colabfold server, additionally pass the `--msa-server` flag with your server:
+
+```shell
+chai fold --use-msa-server --msa-server "https://api.internalcolabserver.com" input.fasta output_folder
+```
+
 ### Programmatic inference
 
 The main entrypoint into the Chai-1 folding code is through the `chai_lab.chai1.run_inference` function. The following script demonstrates how to programmatically provide inputs to the model, and obtain a list of PDB files for downstream analysis:
@@ -71,7 +77,7 @@ CHAI_DOWNLOADS_DIR=/tmp/downloads python ./examples/predict_structure.py
 
 Chai-1 supports MSAs provided as an `aligned.pqt` file. This file format is similar to an `a3m` file, but has additional columns that provide metadata like the source database and sequence pairing keys. We provide code to convert `a3m` files to `aligned.pqt` files. For more information on how to provide MSAs to Chai-1, see [this documentation](examples/msas/README.md).
 
-For user convenience, we also support automatic MSA generation via the ColabFold [MMseqs2](https://github.com/soedinglab/MMseqs2) server via the `--msa-server` flag. As detailed in the ColabFold [repository](https://github.com/sokrypton/ColabFold), please keep in mind that this is a shared resource. Note that the results reported in our preprint and the webserver use a different MSA search strategy than MMseqs2, though we expect results to be broadly similar.
+For user convenience, we also support automatic MSA generation via the ColabFold [MMseqs2](https://github.com/soedinglab/MMseqs2) server via the `--use-msa-server` flag. As detailed in the ColabFold [repository](https://github.com/sokrypton/ColabFold), please keep in mind that this is a shared resource. Note that the results reported in our preprint and the webserver use a different MSA search strategy than MMseqs2, though we expect results to be broadly similar.
 
 </p>
 </details>

--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -270,7 +270,8 @@ def run_inference(
     *,
     output_dir: Path,
     use_esm_embeddings: bool = True,
-    msa_server: bool = False,
+    use_msa_server: bool = False,
+    msa_server: str = "https://api.colabfold.com",
     msa_directory: Path | None = None,
     constraint_path: Path | None = None,
     # expose some params for easy tweaking
@@ -285,7 +286,7 @@ def run_inference(
         ), f"Output directory {output_dir} is not empty."
     torch_device = torch.device(device if device is not None else "cuda:0")
     assert not (
-        msa_server and msa_directory
+        use_msa_server and msa_directory
     ), "Cannot specify both MSA server and directory"
 
     # Prepare inputs
@@ -311,7 +312,7 @@ def run_inference(
     raise_if_too_many_tokens(n_actual_tokens)
 
     # Generated and/or load MSAs
-    if msa_server:
+    if use_msa_server:
         protein_sequences = [
             chain.entity_data.sequence
             for chain in chains
@@ -319,7 +320,9 @@ def run_inference(
         ]
         msa_dir = output_dir / "msas"
         msa_dir.mkdir(parents=True, exist_ok=False)
-        generate_colabfold_msas(protein_seqs=protein_sequences, msa_dir=msa_dir)
+        generate_colabfold_msas(
+            protein_seqs=protein_sequences, msa_dir=msa_dir, msa_server=msa_server
+        )
         msa_context, msa_profile_context = get_msa_contexts(
             chains, msa_directory=msa_dir
         )

--- a/chai_lab/data/dataset/msas/colabfold.py
+++ b/chai_lab/data/dataset/msas/colabfold.py
@@ -341,7 +341,7 @@ def _run_mmseqs2(
     return (a3m_lines, template_paths) if use_templates else a3m_lines
 
 
-def generate_colabfold_msas(protein_seqs: list[str], msa_dir: Path):
+def generate_colabfold_msas(protein_seqs: list[str], msa_dir: Path, msa_server: str):
     """
     Generate MSAs using the ColabFold (https://github.com/sokrypton/ColabFold)
     server.
@@ -374,6 +374,7 @@ def generate_colabfold_msas(protein_seqs: list[str], msa_dir: Path):
             mmseqs_dir,
             # N.B. we can set this to False to disable pairing
             use_pairing=len(protein_seqs) > 1,
+            host_url=msa_server,
             user_agent="chai-lab/0.4.0 feedback@chaidiscovery.com",
         )
         assert isinstance(msas, list)


### PR DESCRIPTION
## Description
If you are using your own colabfold server you would want to point the api calls towards that instead of the public api.colabfold.com server. This provides an interface to do so.

## Motivation
We have our own internal colabfold server to protect our data, and do not want to use the colabfold.com server. 

## Test plan
I have not tested this yet. but will this week as i try to setup chai-1
the changes are quite simple though.

ps: thank you for changing the license, I know many people are eager to try your work here : )

