### PR TITLE
Support for specifying covalent bonds and glycans

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -449,6 +449,7 @@ def run_folding_on_context(
     raise_if_too_many_templates(feature_context.template_context.num_templates)
     raise_if_msa_too_deep(feature_context.msa_context.depth)
     # NOTE profile MSA used only for statistics; no depth check
+    feature_context.structure_context.report_bonds()
 
     ##
     ## Prepare batch

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -145,6 +145,7 @@ def raw_inputs_to_entitites_data(
                 method="none",
                 entity_type=entity_type,
                 subchain_id=_synth_subchain_id(i),
+                original_record=input.sequence,
             )
         )
 

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -19,6 +19,7 @@ from chai_lab.data.dataset.structure.all_atom_structure_context import (
 )
 from chai_lab.data.dataset.structure.chain import Chain
 from chai_lab.data.parsing.fasta import get_residue_name, read_fasta
+from chai_lab.data.parsing.glycans import glycan_string_residues
 from chai_lab.data.parsing.input_validation import (
     constituents_of_modified_fasta,
     identify_potential_entity_types,
@@ -118,6 +119,8 @@ def raw_inputs_to_entitites_data(
                     for r in parsed_sequence
                 ]
                 residues = get_polymer_residues(expanded_sequence, entity_type)
+            case EntityType.MANUAL_GLYCAN:
+                residues = glycan_string_residues(glycan_string=input.sequence)
             case _:
                 raise NotImplementedError
         assert residues is not None
@@ -233,6 +236,8 @@ def read_inputs(fasta_file: str | Path, length_limit: int | None = None) -> list
                 entity_type = EntityType.RNA
             case "dna":
                 entity_type = EntityType.DNA
+            case "glycan":
+                entity_type = EntityType.MANUAL_GLYCAN
             case _:
                 raise ValueError(f"{entity_str} is not a valid entity type")
 

--- a/chai_lab/data/dataset/structure/all_atom_residue_tokenizer.py
+++ b/chai_lab/data/dataset/structure/all_atom_residue_tokenizer.py
@@ -14,6 +14,9 @@ from chai_lab.data.dataset.structure import utils
 from chai_lab.data.dataset.structure.all_atom_structure_context import (
     AllAtomStructureContext,
 )
+from chai_lab.data.dataset.structure.bond_utils import (
+    get_atom_covalent_bond_pairs_from_glycan_string,
+)
 from chai_lab.data.dataset.structure.utils import (
     backbone_atoms_all_present,
     backbone_atoms_indices,
@@ -510,6 +513,15 @@ class AllAtomResidueTokenizer:
                 dtype=torch.bool,
             ),
             symmetries=tokens.symmetries,
+            atom_covalent_bond_indices=get_atom_covalent_bond_pairs_from_glycan_string(
+                glycan_string=(
+                    entity_data.original_record
+                    if entity_data.entity_type == EntityType.MANUAL_GLYCAN
+                    else ""
+                ),
+                token_residue_index=tokens.residue_index,
+                atom_ref_name=tokens.atom_names,
+            ),
         )
 
     def _get_ref_conformer_data(self, residue: Residue) -> ConformerData:

--- a/chai_lab/data/dataset/structure/all_atom_structure_context.py
+++ b/chai_lab/data/dataset/structure/all_atom_structure_context.py
@@ -92,6 +92,19 @@ class AllAtomStructureContext:
     def residue_names(self) -> list[str]:
         return batch_tensorcode_to_string(self.token_residue_name)
 
+    def report_bonds(self) -> None:
+        """Print information about covalent bonds."""
+        for i, (cov_a, cov_b) in enumerate(zip(*self.atom_covalent_bond_indices)):
+            asym_a = self.token_asym_id[cov_a]
+            asym_b = self.token_asym_id[cov_b]
+            res_idx_a = self.token_residue_index[cov_a]
+            res_idx_b = self.token_residue_index[cov_b]
+            resname_a = tensorcode_to_string(self.token_residue_name[cov_a])
+            resname_b = tensorcode_to_string(self.token_residue_name[cov_b])
+            print(
+                f"Bond {i}: {asym_a} {res_idx_a} {resname_a} <> {asym_b} {res_idx_b} {resname_b}"
+            )
+
     def pad(
         self,
         n_tokens: int,

--- a/chai_lab/data/dataset/structure/all_atom_structure_context.py
+++ b/chai_lab/data/dataset/structure/all_atom_structure_context.py
@@ -65,6 +65,13 @@ class AllAtomStructureContext:
     is_distillation: Bool[Tensor, "1"]
     # symmetric atom swap indices
     symmetries: Int[Tensor, "n_atoms n_symmetries"]
+    # token bond feature
+    atom_covalent_bond_indices: tuple[
+        Int[Tensor, "n_bonds"], Int[Tensor, "n_bonds"]
+    ] = (
+        torch.empty(0, dtype=torch.long),
+        torch.empty(0, dtype=torch.long),
+    )
 
     def __post_init__(self):
         # Resolved residues filter should eliminate PDBs with missing residues, but that

--- a/chai_lab/data/dataset/structure/bond_utils.py
+++ b/chai_lab/data/dataset/structure/bond_utils.py
@@ -73,7 +73,7 @@ def get_atom_covalent_bond_pairs_from_constraints(
                 )
                 assert torch.any(left_atoms_mask) and torch.any(right_atoms_mask)
 
-                # Find atoms matching by name
+                # Find atoms matching on atom name
                 left_name_mask = torch.tensor(
                     [n == constraint.atom_nameA for n in atom_ref_name],
                     dtype=torch.bool,

--- a/chai_lab/data/dataset/structure/bond_utils.py
+++ b/chai_lab/data/dataset/structure/bond_utils.py
@@ -14,6 +14,7 @@ from chai_lab.model.utils import get_asym_id_from_subchain_id
 from chai_lab.utils.typing import Int, UInt8, typecheck
 
 
+@typecheck
 def get_atom_covalent_bond_pairs_from_constraints(
     provided_constraints: list[PairwiseInteraction],
     token_residue_index: Int[Tensor, "n_tokens"],
@@ -87,8 +88,14 @@ def get_atom_covalent_bond_pairs_from_constraints(
                 assert (
                     torch.sum(left_atom_mask) == torch.sum(right_atom_mask) == 1
                 ), f"Expect single atoms, got {torch.sum(left_atom_mask)}, {torch.sum(right_atom_mask)}"
-                ret_a.append(torch.where(left_atom_mask)[0].item())  # type: ignore
-                ret_b.append(torch.where(right_atom_mask)[0].item())  # type: ignore
+
+                left_atom_idx = torch.where(left_atom_mask)[0]
+                right_atom_idx = torch.where(right_atom_mask)[0]
+                left_token_idx = atom_token_index[left_atom_idx]
+                right_token_idx = atom_token_index[right_atom_idx]
+
+                ret_a.append(left_token_idx.item())  # type: ignore
+                ret_b.append(right_token_idx.item())  # type: ignore
 
             case PairwiseInteractionType.CONTACT | PairwiseInteractionType.POCKET:
                 # These are handled as constraints, not as bonds

--- a/chai_lab/data/dataset/structure/bond_utils.py
+++ b/chai_lab/data/dataset/structure/bond_utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for details.
+
+import torch
+from torch import Tensor
+
+from chai_lab.data.parsing.glycans import _glycan_string_to_sugars_and_bonds
+from chai_lab.utils.typing import Int, typecheck
+
+
+@typecheck
+def get_atom_covalent_bond_pairs_from_glycan_string(
+    glycan_string: str,
+    token_residue_index: Int[Tensor, "n_tokens"],
+    atom_ref_name: list[str],
+) -> tuple[Int[Tensor, "n_bonds"], Int[Tensor, "n_bonds"]]:
+    """Infer bond pairs between glycans sugar rings."""
+    if not glycan_string:
+        return (
+            torch.zeros(0, dtype=torch.long),
+            torch.zeros(0, dtype=torch.long),
+        )
+
+    assert token_residue_index.numel() == len(atom_ref_name)
+    _sugars, bonds = _glycan_string_to_sugars_and_bonds(glycan_string)
+    left_bonds, right_bonds = [], []
+    for bond in bonds:
+        left_chain_mask = token_residue_index == bond.src_sugar_index
+        left_res_mask = [n == bond.src_atom_name for n in atom_ref_name]
+        right_chain_mask = token_residue_index == bond.dst_sugar_index
+        right_res_mask = [n == bond.dst_atom_name for n in atom_ref_name]
+        left_res = left_chain_mask & torch.tensor(left_res_mask)
+        right_res = right_chain_mask & torch.tensor(right_res_mask)
+        assert left_res.sum() == 1, f"Expected unique atom, got {left_res=}"
+        assert right_res.sum() == 1, f"Expected unique atom, got {right_res=}"
+        left_res_idx, *_ = torch.where(left_res)
+        right_res_idx, *_ = torch.where(right_res)
+        left_bonds.append(left_res_idx.item())
+        right_bonds.append(right_res_idx.item())
+    bonds_to_add = (
+        torch.tensor(left_bonds, dtype=torch.int),
+        torch.tensor(right_bonds, dtype=torch.int),
+    )
+    return bonds_to_add

--- a/chai_lab/data/features/generators/token_bond.py
+++ b/chai_lab/data/features/generators/token_bond.py
@@ -27,7 +27,7 @@ class TokenBondRestraint(FeatureGenerator):
     def get_input_kwargs_from_batch(self, batch: dict[str, Any]) -> dict:
         return dict(
             token_exists_mask=batch["inputs"]["token_exists_mask"],
-            atom_token_index=batch["inputs"]["atom_token_index"].long(),
+            # atom_token_index=batch["inputs"]["atom_token_index"].long(),
             atom_covalent_bond_indices=batch["inputs"]["atom_covalent_bond_indices"],
         )
 
@@ -40,7 +40,7 @@ class TokenBondRestraint(FeatureGenerator):
     def _generate(
         self,
         token_exists_mask: Bool[Tensor, "b n"],
-        atom_token_index: Int[Tensor, "b a"],
+        # atom_token_index: Int[Tensor, "b a"],
         atom_covalent_bond_indices: list[
             tuple[Int[Tensor, "bonds"], Int[Tensor, "bonds"]]
         ],
@@ -51,12 +51,14 @@ class TokenBondRestraint(FeatureGenerator):
         for batch_idx, (left_indices, right_indices) in enumerate(
             atom_covalent_bond_indices
         ):
-            left_token_indices = torch.gather(
-                atom_token_index[batch_idx], dim=0, index=left_indices
-            )
-            right_token_indices = torch.gather(
-                atom_token_index[batch_idx], dim=0, index=right_indices
-            )
-            bond_feature[batch_idx][left_token_indices, right_token_indices] = 1
+            bond_feature[batch_idx][left_indices, right_indices] = 1
+            # left_token_indices = torch.gather(
+            #     atom_token_index[batch_idx], dim=0, index=left_indices
+            # )
+            # right_token_indices = torch.gather(
+            #     atom_token_index[batch_idx], dim=0, index=right_indices
+            # )
+            # print(left_token_indices, right_token_indices)
+            # bond_feature[batch_idx][left_token_indices, right_token_indices] = 1
 
         return self.make_feature(bond_feature.unsqueeze(-1))

--- a/chai_lab/data/features/generators/token_bond.py
+++ b/chai_lab/data/features/generators/token_bond.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for details.
+
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from chai_lab.data.features.feature_type import FeatureType
+from chai_lab.data.features.generators.base import EncodingType, FeatureGenerator
+from chai_lab.utils.tensor_utils import und_self
+from chai_lab.utils.typing import Bool, Int, typecheck
+
+
+class TokenBondRestraint(FeatureGenerator):
+    def __init__(self):
+        """Generates features for covalent bonds between atoms."""
+        super().__init__(
+            ty=FeatureType.TOKEN_PAIR,
+            encoding_ty=EncodingType.IDENTITY,
+            can_mask=False,
+            num_classes=1,
+            mult=1,
+        )
+
+    def get_input_kwargs_from_batch(self, batch: dict[str, Any]) -> dict:
+        return dict(
+            token_exists_mask=batch["inputs"]["token_exists_mask"],
+            atom_token_index=batch["inputs"]["atom_token_index"].long(),
+            atom_covalent_bond_indices=batch["inputs"]["atom_covalent_bond_indices"],
+        )
+
+    @typecheck
+    def apply_mask(self, feature: Tensor, mask: Tensor, mask_ty: FeatureType) -> Tensor:
+        # override masking behavior - just return the unmasked feature
+        return feature
+
+    @typecheck
+    def _generate(
+        self,
+        token_exists_mask: Bool[Tensor, "b n"],
+        atom_token_index: Int[Tensor, "b a"],
+        atom_covalent_bond_indices: list[
+            tuple[Int[Tensor, "bonds"], Int[Tensor, "bonds"]]
+        ],
+    ) -> Tensor:
+        token_pair_mask = und_self(token_exists_mask, "b i, b j -> b i j")
+        bond_feature = torch.zeros_like(token_pair_mask.float())
+
+        for batch_idx, (left_indices, right_indices) in enumerate(
+            atom_covalent_bond_indices
+        ):
+            left_token_indices = torch.gather(
+                atom_token_index[batch_idx], dim=0, index=left_indices
+            )
+            right_token_indices = torch.gather(
+                atom_token_index[batch_idx], dim=0, index=right_indices
+            )
+            bond_feature[batch_idx][left_token_indices, right_token_indices] = 1
+
+        return self.make_feature(bond_feature.unsqueeze(-1))

--- a/chai_lab/data/io/cif_utils.py
+++ b/chai_lab/data/io/cif_utils.py
@@ -8,7 +8,14 @@ from pathlib import Path
 import gemmi
 import modelcif
 import torch
-from ihm import ChemComp, DNAChemComp, LPeptideChemComp, NonPolymerChemComp, RNAChemComp
+from ihm import (
+    ChemComp,
+    DNAChemComp,
+    LPeptideChemComp,
+    NonPolymerChemComp,
+    RNAChemComp,
+    SaccharideChemComp,
+)
 from modelcif import Assembly, AsymUnit, Entity, dumper, model
 from torch import Tensor
 
@@ -93,6 +100,8 @@ def _to_chem_component(res_name_3: str, entity_type: int):
         case EntityType.LIGAND.value:
             code = res_name_3
             return NonPolymerChemComp(res_name_3)
+        case EntityType.MANUAL_GLYCAN.value:
+            return SaccharideChemComp(id=res_name_3, name=res_name_3)
         case EntityType.PROTEIN.value:
             code = restype_3to1.get(res_name_3, res_name_3)
             one_letter_code = gemmi.find_tabulated_residue(res_name_3).one_letter_code
@@ -105,7 +114,7 @@ def _to_chem_component(res_name_3: str, entity_type: int):
             code = res_name_3
             return RNAChemComp(res_name_3, code, code_canonical=code)
         case _:
-            raise NotImplementedError
+            raise NotImplementedError(f"Cannot handle entity type: {entity_type}")
 
 
 def sequence_to_chem_comps(sequence: list[str], entity_type: int) -> list[ChemComp]:

--- a/chai_lab/data/parsing/glycans.py
+++ b/chai_lab/data/parsing/glycans.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for details.
+
+"""Parsing logic for glycans.
+
+- Each sugar in the glycan gets a distinct residue
+    - Each residue has an increasing label seq
+
+Example glycan strings:
+MAN(6-1 FUC)(4-1 MAN)
+"""
+
+import re
+from functools import lru_cache
+
+from attr import dataclass
+
+from chai_lab.data import residue_constants as rc
+from chai_lab.data.parsing.structure.residue import Residue
+
+
+@dataclass(frozen=True)
+class GlycosidicBond:
+    src_sugar_index: int  # 0-indexed
+    dst_sugar_index: int  # 0-indexed
+    src_atom: int  # 1-indexed
+    dst_atom: int  # 1-indexed
+
+    def __post_init__(self):
+        assert self.src_sugar_index != self.dst_sugar_index
+        assert self.src_atom > 0 and self.dst_atom > 0
+
+    @property
+    def src_atom_name(self) -> str:
+        return f"C{self.src_atom}"
+
+    @property
+    def dst_atom_name(self) -> str:
+        return f"C{self.dst_atom}"
+
+
+@lru_cache(maxsize=32)
+def _glycan_string_to_sugars_and_bonds(
+    glycan_string: str,
+) -> tuple[list[str], list[GlycosidicBond]]:
+    """Parses the glycan string to its constituent sugars and bonds."""
+    sugars: list[str] = []  # Tracks all sugars
+    parent_sugar_idx: list[int] = []  # Tracks the parent sugar for bond formation
+    bonds: list[GlycosidicBond] = []
+    open_count, closed_count = 0, 0
+    for i in range(len(glycan_string)):
+        char = glycan_string[i]
+        if char == " ":
+            continue
+        if char == "(":
+            open_count += 1
+            continue
+        if char == ")":
+            closed_count += 1
+            parent_sugar_idx.pop()  # Remove
+            continue
+        chunk = glycan_string[i : i + 3]
+        if re.match(r"[A-Z]{3}", chunk):
+            sugars.append(chunk)
+            parent_sugar_idx.append(len(sugars) - 1)  # latest sugar
+        elif re.match(r"[1-6]{1}-[1-6]{1}", chunk):
+            s, d = chunk.split("-")
+            assert parent_sugar_idx
+            bonds.append(
+                GlycosidicBond(
+                    src_sugar_index=parent_sugar_idx[-1],
+                    dst_sugar_index=len(sugars),  # Anticipate next
+                    src_atom=int(s),
+                    dst_atom=int(d),
+                )
+            )
+    assert open_count == closed_count
+    return sugars, bonds
+
+
+def glycan_string_residues(glycan_string: str) -> list[Residue]:
+    sugars, _bonds = _glycan_string_to_sugars_and_bonds(glycan_string)
+    retval = [
+        Residue(
+            name=sugar,
+            label_seq=i + 1,
+            restype=rc.residue_types_with_nucleotides_order["X"],
+            residue_index=i,
+            is_missing=False,
+            b_factor_or_plddt=0.0,
+            conformer_data=None,
+            is_covalent_bonded=True,
+        )
+        for i, sugar in enumerate(sugars)
+    ]
+    return retval

--- a/chai_lab/data/parsing/restraints.py
+++ b/chai_lab/data/parsing/restraints.py
@@ -96,9 +96,7 @@ class PairwiseInteraction:
     def res_idxA_pos(self) -> int:
         """1-indexed position of residue A; 0 indicates not given."""
         s = self.res_idxA[1:]
-        if len(s) == 0:
-            return 0
-        return int(s)
+        return int(s) if s else 0
 
     @property
     def res_idxB_name(self) -> str:
@@ -106,12 +104,10 @@ class PairwiseInteraction:
         return self.res_idxB[0]
 
     @property
-    def res_idxB_pos(self) -> int | None:
+    def res_idxB_pos(self) -> int:
         """1-indexed position of residue B; 0 indicates not given."""
         s = self.res_idxB[1:]
-        if len(s) == 0:
-            return 0
-        return int(s)
+        return int(s) if s else 0
 
     def to_table_entry(self) -> dict[str, str | float]:
         """Format as table entry, sans leading restraint_id column."""

--- a/chai_lab/data/parsing/restraints.py
+++ b/chai_lab/data/parsing/restraints.py
@@ -94,8 +94,11 @@ class PairwiseInteraction:
 
     @property
     def res_idxA_pos(self) -> int:
-        """1-indexed position of residue A."""
-        return int(self.res_idxA[1:])
+        """1-indexed position of residue A; 0 indicates not given."""
+        s = self.res_idxA[1:]
+        if len(s) == 0:
+            return 0
+        return int(s)
 
     @property
     def res_idxB_name(self) -> str:
@@ -103,9 +106,12 @@ class PairwiseInteraction:
         return self.res_idxB[0]
 
     @property
-    def res_idxB_pos(self) -> int:
-        """1-indexed position of residue B."""
-        return int(self.res_idxB[1:])
+    def res_idxB_pos(self) -> int | None:
+        """1-indexed position of residue B; 0 indicates not given."""
+        s = self.res_idxB[1:]
+        if len(s) == 0:
+            return 0
+        return int(s)
 
     def to_table_entry(self) -> dict[str, str | float]:
         """Format as table entry, sans leading restraint_id column."""

--- a/chai_lab/data/parsing/structure/all_atom_entity_data.py
+++ b/chai_lab/data/parsing/structure/all_atom_entity_data.py
@@ -34,6 +34,7 @@ class AllAtomEntityData:
     entity_type: EntityType
     subchain_id: str
     is_d_polypeptide: bool = False  # NOTE (mostly) exists for eval set construction
+    original_record: str = ""  # NOTE for glycan parsing
 
     def __post_init__(self):
         assert (

--- a/chai_lab/data/parsing/structure/entity_type.py
+++ b/chai_lab/data/parsing/structure/entity_type.py
@@ -16,3 +16,4 @@ class EntityType(Enum):
     POLYMER_HYBRID = 4
     WATER = 5
     UNKNOWN = 6
+    MANUAL_GLYCAN = 7  # NOTE glycan parsing

--- a/chai_lab/data/parsing/structure/residue.py
+++ b/chai_lab/data/parsing/structure/residue.py
@@ -77,6 +77,7 @@ class Residue:
     b_factor_or_plddt: float
     conformer_data: ConformerData | None
     smiles: str | None = None
+    is_covalent_bonded: bool = False
 
 
 def get_restype(

--- a/examples/glycosylation/bonds.restraints
+++ b/examples/glycosylation/bonds.restraints
@@ -1,2 +1,2 @@
 chainA,res_idxA,chainB,res_idxB,connection_type,confidence,min_distance_angstrom,max_distance_angstrom,comment,restraint_id
-A,N437@N,B,@C4,covalent,1.0,0.0,6.0,protein-glycan,restraint_1
+A,N436@N,B,@C4,covalent,1.0,0.0,6.0,protein-glycan,restraint_1

--- a/examples/glycosylation/bonds.restraints
+++ b/examples/glycosylation/bonds.restraints
@@ -1,0 +1,2 @@
+chainA,res_idxA,chainB,res_idxB,connection_type,confidence,min_distance_angstrom,max_distance_angstrom,comment,restraint_id
+A,N437@N,B,@C4,covalent,1.0,0.0,6.0,protein-glycan,restraint_1

--- a/examples/glycosylation/predict_glycosylated.py
+++ b/examples/glycosylation/predict_glycosylated.py
@@ -1,0 +1,36 @@
+import logging
+import shutil
+from pathlib import Path
+
+from chai_lab.chai1 import run_inference
+
+glycosylated_fasta = """
+>protein|1AC5
+LPSSEEYKVAYELLPGLSEVPDPSNIPQMHAGHIPLRSEDADEQDSSDLEYFFWKFTNNDSNGNVDRPLIIWLNGGPGCSSMDGALVESGPFRVNSDGKLYLNEGSWISKGDLLFIDQPTGTGFSVEQNKDEGKIDKNKFDEDLEDVTKHFMDFLENYFKIFPEDLTRKIILSGESYAGQYIPFFANAILNHNKFSKIDGDTYDLKALLIGNGWIDPNTQSLSYLPFAMEKKLIDESNPNFKHLTNAHENCQNLINSASTDEAAHFSYQECENILNLLLSYTRESSQKGTADCLNMYNFNLKDSYPSCGMNWPKDISFVSKFFSTPGVIDSLHLDSDKIDHWKECTNSVGTKLSNPISKPSIHLLPGLLESGIEIVLFNGDKDLICNNKGVLDTIDNLKWGGIKGFSDDAVSFDWIHKSKSTDDSEEFSGYVKYDRNLTFVSVYNASHMVPFDKSLVSRGIVDIYSNDVMIIDNNGKNVMITT
+>glycan|two-sugar
+NAG(1-4 NAG)
+"""
+
+fasta_path = Path("/tmp/example.fasta")
+fasta_path.write_text(glycosylated_fasta)
+
+# Inference expects an empty directory; enforce this
+output_dir = Path("/tmp/outputs")
+if output_dir.exists():
+    logging.warning(f"Removing old output directory: {output_dir}")
+    shutil.rmtree(output_dir)
+output_dir.mkdir(exist_ok=True)
+
+candidates = run_inference(
+    fasta_file=fasta_path,
+    output_dir=output_dir,
+    constraint_path=Path(__file__).with_name("bonds.restraints"),
+    # 'default' setup
+    num_trunk_recycles=1,
+    num_diffn_timesteps=200,
+    seed=42,
+    device="cuda:0",
+    use_esm_embeddings=True,
+)
+
+cif_paths = candidates.cif_paths

--- a/examples/predict_structure.py
+++ b/examples/predict_structure.py
@@ -1,3 +1,5 @@
+import logging
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -26,7 +28,12 @@ CCCCCCCCCCCCCC(=O)O
 fasta_path = Path("/tmp/example.fasta")
 fasta_path.write_text(example_fasta)
 
+# Inference expects an empty directory; enforce this
 output_dir = Path("/tmp/outputs")
+if output_dir.exists():
+    logging.warning(f"Removing old output directory: {output_dir}")
+    shutil.rmtree(output_dir)
+output_dir.mkdir(exist_ok=True)
 
 candidates = run_inference(
     fasta_file=fasta_path,


### PR DESCRIPTION
## Description
Add support for `TokenBondRestraint`, which allows specifying covalently bound ligands to residues, including glycans. 

## Motivation
Glycan support.

## Test plan
WIP
