### PR TITLE
Fix case where empty list is passed to colabfold MSA generation

### DIFF
--- a/chai_lab/data/dataset/msas/colabfold.py
+++ b/chai_lab/data/dataset/msas/colabfold.py
@@ -363,6 +363,10 @@ def generate_colabfold_msas(
     assert msa_dir.is_dir(), "MSA directory must be a dir"
     assert not any(msa_dir.iterdir()), "MSA directory must be empty"
 
+    if not protein_seqs:
+        logger.warning("No protein sequences for MSA generation; this is a no-op.")
+        return
+
     with tempfile.TemporaryDirectory() as tmp_dir_path:
         tmp_dir = Path(tmp_dir_path)
 

--- a/chai_lab/data/dataset/msas/colabfold.py
+++ b/chai_lab/data/dataset/msas/colabfold.py
@@ -349,7 +349,7 @@ def generate_colabfold_msas(
 ):
     """
     Generate MSAs using the ColabFold (https://github.com/sokrypton/ColabFold)
-    server.
+    server. No-op if no protein sequences are given.
 
     N.B. the MSAs in our technical report were generated using jackhmmer, not
     ColabFold, so we would expect some difference in results.
@@ -362,7 +362,6 @@ def generate_colabfold_msas(
     """
     assert msa_dir.is_dir(), "MSA directory must be a dir"
     assert not any(msa_dir.iterdir()), "MSA directory must be empty"
-
     if not protein_seqs:
         logger.warning("No protein sequences for MSA generation; this is a no-op.")
         return


### PR DESCRIPTION
## Description
Passing an empty list to colabfold MSA generation (for example, when MSA generation is enabled for a complex without protein sequences) would previously cause an error, as the server does not expect empty inputs. Adds logic to short circuit on empty input.

## Motivation
Fixes https://github.com/chaidiscovery/chai-lab/issues/206

## Test plan
Tested locally.
