### PR TITLE
Add test for ion charge

### DIFF
--- a/tests/test_inference_dataset.py
+++ b/tests/test_inference_dataset.py
@@ -52,3 +52,4 @@ def test_ions_parsing(tokenizer: AllAtomResidueTokenizer):
     chain = chains[0]
     assert chain.structure_context.num_atoms == 1
     assert chain.structure_context.atom_ref_charge == 2
+    assert chain.structure_context.atom_ref_element.item() == 12


### PR DESCRIPTION
## Description
Ions specified as SMILES strings should carry the correct charge.

## Motivation
Check behavior raised in https://github.com/chaidiscovery/chai-lab/issues/194

## Test plan
Added test; test passes.
