### PR TITLE
Fix atom labeling so they can be named in constraints

### DIFF
--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -157,6 +157,12 @@ class RefConformerGenerator:
 
         AllChem.EmbedMultipleConfs(mol_with_hs, numConfs=1, params=params)
         AllChem.RemoveHs(mol_with_hs)
+        
+        element_counter = defaultdict(int)
+        for i, atom in enumerate(mol_with_hs.GetAtoms()):
+            elem = atom.GetSymbol()
+            element_counter[elem] += 1
+            atom.SetProp("name", elem + str(element_counter[elem]))
         for i, atom in enumerate(mol_with_hs.GetAtoms()):
             atom.SetProp("name", atom.GetSymbol()+str(i+1))
         retval = self._load_ref_conformer_from_rdkit(mol_with_hs)

--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -4,6 +4,7 @@
 
 import logging
 from pathlib import Path
+from collections import defaultdict
 
 import antipickle
 import torch

--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -159,7 +159,7 @@ class RefConformerGenerator:
         AllChem.EmbedMultipleConfs(mol_with_hs, numConfs=1, params=params)
         AllChem.RemoveHs(mol_with_hs)
         
-        element_counter = defaultdict(int)
+        element_counter: dict = defaultdict(int)
         for i, atom in enumerate(mol_with_hs.GetAtoms()):
             elem = atom.GetSymbol()
             element_counter[elem] += 1

--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -3,8 +3,8 @@
 # See the LICENSE file for details.
 
 import logging
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 import antipickle
 import torch

--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -163,8 +163,7 @@ class RefConformerGenerator:
             elem = atom.GetSymbol()
             element_counter[elem] += 1
             atom.SetProp("name", elem + str(element_counter[elem]))
-        for i, atom in enumerate(mol_with_hs.GetAtoms()):
-            atom.SetProp("name", atom.GetSymbol()+str(i+1))
+    
         retval = self._load_ref_conformer_from_rdkit(mol_with_hs)
         retval.atom_names = [a.upper() for a in retval.atom_names]
         return retval

--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -158,7 +158,7 @@ class RefConformerGenerator:
         AllChem.EmbedMultipleConfs(mol_with_hs, numConfs=1, params=params)
         AllChem.RemoveHs(mol_with_hs)
         for atom in mol_with_hs.GetAtoms():
-            atom.SetProp("name", atom.GetSymbol())
+            atom.SetProp("name", atom.GetSymbol()+str(i+1))
         retval = self._load_ref_conformer_from_rdkit(mol_with_hs)
         retval.atom_names = [a.upper() for a in retval.atom_names]
         return retval

--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -157,7 +157,7 @@ class RefConformerGenerator:
 
         AllChem.EmbedMultipleConfs(mol_with_hs, numConfs=1, params=params)
         AllChem.RemoveHs(mol_with_hs)
-        for atom in mol_with_hs.GetAtoms():
+        for i, atom in enumerate(mol_with_hs.GetAtoms()):
             atom.SetProp("name", atom.GetSymbol()+str(i+1))
         retval = self._load_ref_conformer_from_rdkit(mol_with_hs)
         retval.atom_names = [a.upper() for a in retval.atom_names]


### PR DESCRIPTION
## Description
Old behavior named ligand atoms by element. Added 1-indexed index to element symbol.

## Motivation
Atoms require a unique label so they can be specified in constraints. 
