### PR TITLE
Load ESM2 in bf16 if supported

### DIFF
--- a/chai_lab/data/dataset/embeddings/esm.py
+++ b/chai_lab/data/dataset/embeddings/esm.py
@@ -31,11 +31,18 @@ esm_cache_folder = downloads_path.joinpath("esm")
 def esm_model(model_name: str, device):
     """Context transiently keeps ESM model on specified device."""
     from transformers import EsmModel
+    from transformers.utils.import_utils import is_torch_bf16_gpu_available
 
     if len(_esm_model) == 0:
         # lazy loading of the model
         _esm_model.append(
-            EsmModel.from_pretrained(model_name, cache_dir=esm_cache_folder)
+            EsmModel.from_pretrained(
+                model_name,
+                cache_dir=esm_cache_folder,
+                torch_dtype=(
+                    torch.float16 if is_torch_bf16_gpu_available() else torch.bfloat16
+                ),
+            )
         )
 
     [model] = _esm_model

--- a/chai_lab/data/dataset/embeddings/esm.py
+++ b/chai_lab/data/dataset/embeddings/esm.py
@@ -40,7 +40,7 @@ def esm_model(model_name: str, device):
                 model_name,
                 cache_dir=esm_cache_folder,
                 torch_dtype=(
-                    torch.float16 if is_torch_bf16_gpu_available() else torch.bfloat16
+                    torch.bfloat16 if is_torch_bf16_gpu_available() else torch.float16
                 ),
             )
         )


### PR DESCRIPTION
## Description
Updated ESM2 model load to use bfloat16 (if supported).

## Motivation
Slightly improved VRAM usage for greater support on A10 gpus

## Test plan
Run on test data using g5.2xlarge instances on AWS
