### PR TITLE
auto-detect same entity for non-ligands

### DIFF
--- a/chai_lab/data/io/cif_utils.py
+++ b/chai_lab/data/io/cif_utils.py
@@ -104,7 +104,10 @@ def get_chains_metadata(
 
         sequence = [chain_token_res_names[i] for i in any_token_in_resi]
 
-        entity_key = (entity_type, *sequence)
+        if entity_type == EntityType.LIGAND.value:
+            entity_key = (entity_type, asym_id)  # each ligand = separate entity.
+        else:
+            entity_key = (entity_type, *sequence)
 
         asym_entity_name = asymid2entity_name[asym_id]
         if entity_key not in entity_key2ihm_entity:

--- a/chai_lab/data/io/cif_utils.py
+++ b/chai_lab/data/io/cif_utils.py
@@ -81,6 +81,7 @@ def get_chains_metadata(
     token_res_names = context.token_res_names_to_string
 
     asym_id2asym_unit = {}
+    entity_key2ihm_entity = {}
 
     for asym_id, entity_type in context.asym_id2entity_type.items():
         assert asym_id != 0, "zero is padding for asym_id"
@@ -96,27 +97,30 @@ def get_chains_metadata(
         any_token_in_resi = residue_indices.new_zeros([max_res + 1]) - 99
 
         any_token_in_resi[residue_indices] = torch.arange(
-            len(residue_indices),
-            dtype=residue_indices.dtype,
-            device=residue_indices.device,
+            len(residue_indices), dtype=any_token_in_resi.dtype
         )
 
         assert any_token_in_resi.min() >= 0
 
         sequence = [chain_token_res_names[i] for i in any_token_in_resi]
 
-        chain_id_str = _get_chain_letter(asym_id)
+        entity_key = (entity_type, *sequence)
 
-        asym_id2asym_unit[asym_id] = AsymUnit(
-            entity=Entity(
+        asym_entity_name = asymid2entity_name[asym_id]
+        if entity_key not in entity_key2ihm_entity:
+            entity_key2ihm_entity[entity_key] = Entity(
                 # sequence is a list of ChemComponents for aminoacids/bases
                 sequence=[
                     _to_chem_component(resi, entity_type, asym_id) for resi in sequence
                 ],
-                description=asymid2entity_name[asym_id],
-            ),
-            details=f"Chain {chain_id_str}",
-            id=chain_id_str,
+                # will be named same as first among replicas
+                description=f"Entity {asym_entity_name}",
+            )
+
+        asym_id2asym_unit[asym_id] = AsymUnit(
+            entity=entity_key2ihm_entity[entity_key],
+            details=f"Chain {asym_entity_name}",
+            id=asym_entity_name,
         )
 
     return asym_id2asym_unit


### PR DESCRIPTION
## Description / Motivation

`ihm` does not like when complex has identical entities, even with different names (and we for simplicity created single entity per asym_id).

Here is their test: https://github.com/ihmwg/python-ihm/blob/cc4aaded6f705cd3e22de48c0ca9865b05f955da/test/test_dumper.py#L507

this commit introduces automated detection of same entity, entity is named after the first entity replica (e.g. `Entity example-peptide-copy1` for example below).

## Test plan

run with FASTA input:

```
>protein|name=peptide-1
AGSHSMR
>protein|name=peptide-2
AGSHSMR
>protein|name=peptide-3
AGSHSMRAA
>protein|name=peptide-4
AGSHSMRAA
>ligand|name=ligand-1
C
>ligand|name=ligand-2
C
>ligand|name=ligand-3
CC
>ligand|name=ligand-4
CC
```

