### PR TITLE
expose num-diffn-samples to allow arbitrary number of samples

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -443,6 +443,7 @@ def run_inference(
     # expose some params for easy tweaking
     num_trunk_recycles: int = 3,
     num_diffn_timesteps: int = 200,
+    num_diffn_samples: int = 5,
     seed: int | None = None,
     device: str | None = None,
     low_memory: bool = True,
@@ -470,6 +471,7 @@ def run_inference(
         output_dir=output_dir,
         num_trunk_recycles=num_trunk_recycles,
         num_diffn_timesteps=num_diffn_timesteps,
+        num_diffn_samples=num_diffn_samples,
         seed=seed,
         device=torch_device,
         low_memory=low_memory,
@@ -488,6 +490,7 @@ def run_folding_on_context(
     # expose some params for easy tweaking
     num_trunk_recycles: int = 3,
     num_diffn_timesteps: int = 200,
+    num_diffn_samples: int = 5, 
     seed: int | None = None,
     device: torch.device | None = None,
     low_memory: bool,
@@ -690,7 +693,7 @@ def run_folding_on_context(
             **static_diffusion_inputs,
         )
 
-    num_diffn_samples = 5  # Fixed at export time
+    num_diffn_samples = num_diffn_samples  # changed to be a parameter at export time
     inference_noise_schedule = InferenceNoiseSchedule(
         s_max=DiffusionConfig.S_tmax,
         s_min=4e-4,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The num-diffn-samples variable is hard-coded in `chai1.py`, this commit exposes it to be a parameter which allows user to run predictions with arbitrary number of samples.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More prediction samplings might increase the chance of predicting more accurate structures.
Related issue: https://github.com/chaidiscovery/chai-lab/issues/257#issue-2753371168

