### PR TITLE
Update asym chain names to be A, B, C, D, ...

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -906,9 +906,9 @@ def run_folding_on_context(
             bfactors=scaled_plddt_scores_per_atom,
             output_batch=inputs,
             write_path=cif_out_path,
+            # Set asym names to be A, B, C, ...
             asym_entity_names={
-                i: c.entity_data.entity_name
-                for i, c in enumerate(feature_context.chains, start=1)
+                i + 1: chr(i + 65) for i in range(len(feature_context.chains))
             },
         )
         cif_paths.append(cif_out_path)


### PR DESCRIPTION
## Description
Updates chain names to be A, B, C, ... instead of "protein-0-0", "protein-1-0", etc. This is more in line with how asyms are named in PDB and such. 

## Test plan
Local inference run, chains are named correctly and are recognized by PyMOL as expected.
