### PR TITLE
Misc. improvements to templates

### DIFF
--- a/chai_lab/data/dataset/templates/load.py
+++ b/chai_lab/data/dataset/templates/load.py
@@ -382,7 +382,7 @@ def get_template_data(
                         f"Skipping {template_hit} due to mismatched sequences: {context_alignment=} {original_alignment=}"
                     )
                     continue
-            except Exception:
+            except IndexError:
                 logger.warning(
                     f"Skipping {template_hit} due to exception when checking sequences",
                     exc_info=True,

--- a/chai_lab/data/dataset/templates/load.py
+++ b/chai_lab/data/dataset/templates/load.py
@@ -93,6 +93,10 @@ class LoadedTemplate:
         return self.template_hit.query_pdb_id
 
     @property
+    def hit_identifier(self) -> str:
+        return f"{self.template_hit.pdb_id}|{self.template_hit.chain_id}"
+
+    @property
     def template_hit_indices(self) -> Int[Tensor, "n_tokens"]:
         """Indices of hit within full hit sequence."""
         return self.template_hit.indices_hit
@@ -356,25 +360,32 @@ def get_template_data(
         # Check that the loaded version based on an AllAtomStructureContext matches what
         # we expect from the "raw" TemplateHit
         if strict_subsequence_check:
-            original_alignment = "".join(
-                [
-                    c
-                    for c in template_hit.query_seq_realigned
-                    if c.isupper() or not c.isalpha()  # Keep upper and "-"
-                ]
-            )
-            context_alignment = "".join(
-                [
-                    rc.residue_types_with_nucleotides[i]
-                    for i in template.template_restype.tolist()
-                ]
-            )
-            # NOTE before these are all loaded into a TemplateContext, they do not
-            # contain any flanking gap chars "-" so we do not check that the flanking
-            # gaps are equal.
-            if context_alignment not in original_alignment:
+            try:
+                original_alignment = "".join(
+                    [
+                        c
+                        for c in template_hit.query_seq_realigned
+                        if c.isupper() or not c.isalpha()  # Keep upper and "-"
+                    ]
+                )
+                context_alignment = "".join(
+                    [
+                        rc.residue_types_with_nucleotides[i]
+                        for i in template.template_restype.tolist()
+                    ]
+                )
+                # NOTE before these are all loaded into a TemplateContext, they do not
+                # contain any flanking gap chars "-" so we do not check that the flanking
+                # gaps are equal.
+                if context_alignment not in original_alignment:
+                    logger.warning(
+                        f"Skipping {template_hit} due to mismatched sequences: {context_alignment=} {original_alignment=}"
+                    )
+                    continue
+            except Exception:
                 logger.warning(
-                    f"Mismatched sequences loading {template_hit}: {context_alignment=} {original_alignment=}"
+                    f"Skipping {template_hit} due to exception when checking sequences",
+                    exc_info=True,
                 )
                 continue
 
@@ -393,4 +404,7 @@ def get_template_data(
             f"Templates for {pdb_id} | {len(template_data)} remain, dropped hits: {drop_count}"
         )
 
+    logger.info(
+        f"Loaded {len(template_data)} templates: {[t.hit_identifier for t in template_data]}"
+    )
     return template_data

--- a/chai_lab/data/parsing/templates/template_hit.py
+++ b/chai_lab/data/parsing/templates/template_hit.py
@@ -45,6 +45,9 @@ class TemplateHit:
                 "hit metadata in source file."
             )
 
+        if h_i[-1] >= self.hit_tokens.numel():
+            raise ValueError(f"Hit indices exceed size of hit: {h_i} {self.hit_tokens}")
+
         if not self.hit_end > self.hit_start:
             raise ValueError(f"Invalid hit start/end: {self.hit_start} {self.hit_end}")
 

--- a/chai_lab/tools/kalign.py
+++ b/chai_lab/tools/kalign.py
@@ -71,7 +71,7 @@ def kalign_query_to_reference(
     """
     assert (
         shutil.which("kalign") is not None
-    ), "Could not find kalign in your PATH; kalign is required for templates"
+    ), "kalign is required for templates, but was not found in PATH. Try 'apt install kalign'?"
 
     query = query.upper().replace("-", "")
     with TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Description
- try/except around block checking sequences. This works in the vast majority of cases, but can hit indexing errors if there is a mismatch between the template database missing residues and the residues actually marked as missing in the reference CIF structures.
- Additional checks + logging.

## Motivation
Address some corner cases.

## Test plan
Tested locally.
