### PR TITLE
Remove incorrect check

### DIFF
--- a/chai_lab/data/parsing/templates/template_hit.py
+++ b/chai_lab/data/parsing/templates/template_hit.py
@@ -45,9 +45,6 @@ class TemplateHit:
                 "hit metadata in source file."
             )
 
-        if h_i[-1] >= self.hit_tokens.numel():
-            raise ValueError(f"Hit indices exceed size of hit: {h_i} {self.hit_tokens}")
-
         if not self.hit_end > self.hit_start:
             raise ValueError(f"Invalid hit start/end: {self.hit_start} {self.hit_end}")
 


### PR DESCRIPTION
## Description
Remove incorrect check on indices. This was added in #315 and was apparently not thoroughly tested enough.

## Motivation
Fixes https://github.com/chaidiscovery/chai-lab/issues/322

## Test plan
Remove check; issue goes away. Subsequent checks ensuring that template sequence matches sequence being folded still passes, so this check clearly wasn't working as intended.
