### PR TITLE
update rdkit version

### DIFF
--- a/chai_lab/data/sources/rdkit.py
+++ b/chai_lab/data/sources/rdkit.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import antipickle
 import torch
 from rdkit import Chem
-from rdkit.Chem import AllChem
+from rdkit.Chem import rdDistGeom, rdmolops
 
 # for some reason calling Chem.rdDetermineBonds doesnt work
 from rdkit.Chem.rdDetermineBonds import DetermineBonds
@@ -147,7 +147,7 @@ class RefConformerGenerator:
 
         mol_with_hs = Chem.AddHs(mol)
 
-        params = AllChem.ETKDGv3()
+        params = rdDistGeom.ETKDGv3()
         params.useSmallRingTorsions = True
         params.randomSeed = 123
         params.useChirality = True
@@ -156,8 +156,8 @@ class RefConformerGenerator:
         params.maxAttempts = 10_000
         params.useRandomCoords = True
 
-        AllChem.EmbedMultipleConfs(mol_with_hs, numConfs=1, params=params)
-        AllChem.RemoveHs(mol_with_hs)
+        rdDistGeom.EmbedMultipleConfs(mol_with_hs, numConfs=1, params=params)
+        rdmolops.RemoveHs(mol_with_hs)
 
         element_counter: dict = defaultdict(int)
         for atom in mol_with_hs.GetAtoms():

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,8 @@ tqdm~=4.66
 
 # data import/export, application-specific
 gemmi~=0.6.3       # pdb/mmcif parsing
-rdkit==2023.9.5    # parsing of ligands. 2023.9.6 has broken type stubs
+rdkit~=2024.9.5    # we likely support other versions, 
+                   #  but typing is not consistent across rdkit versions, and mypy complain
 biopython>=1.83    # parsing, data access
 antipickle==0.2.0  # save/load heterogeneous python structures
 tmtools>=0.0.3     # Python bindings for the TM-align algorithm


### PR DESCRIPTION
## Description / motivation

There is an inconsistency in rdkit typing that makes 2023.9.5 typing-incompatible with later versions.

However later versions provide binaries on PyPI for python 3.13+. So let's just migrate the code and switch to new version.

Checked typing and ran `predict_structure.py`