### PR TITLE
relax torch version + rework deps

### DIFF
--- a/chai_lab/data/dataset/structure/all_atom_structure_context.py
+++ b/chai_lab/data/dataset/structure/all_atom_structure_context.py
@@ -5,6 +5,7 @@
 import logging
 from dataclasses import asdict, dataclass
 from functools import cached_property, partial
+from typing import Any
 
 import torch
 from torch import Tensor
@@ -494,7 +495,7 @@ class AllAtomStructureContext:
         )
 
     def to(self, device: torch.device | str) -> "AllAtomStructureContext":
-        dict_ = {
+        dict_: dict[str, Any] = {
             k: v.to(device) if torch.is_tensor(v) else v
             for k, v in asdict(self).items()
         }

--- a/requirements.dev
+++ b/requirements.dev
@@ -4,3 +4,9 @@ ruff==0.6.3 # in sync with pre-commit-hook
 mypy
 pytest
 ipykernel~=6.27 # needed by vs code to run notebooks in devcontainer
+
+# types/stubs are required by mypy
+pandas-stubs
+types-pyyaml
+types-tqdm
+types-requests

--- a/requirements.in
+++ b/requirements.in
@@ -1,12 +1,5 @@
-# types/stubs are required by mypy
-pandas-stubs
-types-pyyaml
-types-tqdm
-typing-extensions
-types-requests
-
 # CLI, administrator tools
-typer~=0.12        # CLI generator
+typer-slim~=0.12        # CLI generator
 # pydantic~=2.5      # serialization/deserialization of configs
 
 # seaborn
@@ -14,6 +7,7 @@ matplotlib
 
 # misc
 tqdm~=4.66
+typing-extensions
 
 # data import/export, application-specific
 gemmi~=0.6.3       # pdb/mmcif parsing
@@ -24,11 +18,6 @@ antipickle==0.2.0  # save/load heterogeneous python structures
 tmtools>=0.0.3     # Python bindings for the TM-align algorithm
 modelcif>=1.0      # mmcif writing, confirmed to work currently latest 1.0
 
-# commented out following optional dependencies for release on pypi
-# dockq metric for comparing predicted pdbs and ground truth pdbs
-# dockq @ git+https://github.com/bjornwallner/DockQ.git@v2.1.1
-# pip-compatible minimized version of anarci
-# anarci @ git+https://github.com/arogozhnikov/microANARCI@d81823395d0c3532d6e033d80b036b4aa4a4565e
 
 # computing, dl
 numpy~=1.21
@@ -39,6 +28,5 @@ numba>=0.59
 einops~=0.8
 jaxtyping>=0.2.25   # versions <0.2.25 do not easily support runtime typechecking
 beartype>=0.18      # compatible typechecker to use with jaxtyping
-# do not use 2.2 because https://github.com/pytorch/pytorch/issues/122385
-torch~=2.3.1
+torch>=2.3.1,<2.7   # 2.2 is broken, 2.3.1 is confirmed to work correctly
 transformers~=4.44  # for esm inference


### PR DESCRIPTION
relax torch version, move type-stubs to dev deps, use typer-slim to reduce deps bloat, clean out some commented packages

fix #339 

Tested: 

- rebuilt container, run `chai-lab fold ...`, and ran `chai-lab fold --help`
- create an empty venv, install only chai-lab, run initial example
- confirmed sensible outputs with 2.6.0