### PR TITLE
Fix overaggressive templates file check

### DIFF
--- a/chai_lab/data/parsing/templates/m8.py
+++ b/chai_lab/data/parsing/templates/m8.py
@@ -52,7 +52,7 @@ def parse_m8_to_template_hits(
     m8_path: Path,
     template_cif_folder: Path | None = None,
 ) -> Iterator[TemplateHit]:
-    assert m8_path.is_file() and m8_path.stat().st_size > 0
+    assert m8_path.is_file()
 
     if template_cif_folder is not None:
         template_cif_folder.mkdir(parents=True, exist_ok=True)
@@ -127,12 +127,3 @@ def parse_m8_to_template_hits(
                 exc_info=True,
             )
             pass
-
-
-if __name__ == "__main__":
-    for _ in parse_m8_to_template_hits(
-        "101",
-        "DIQMTQSPSSLSGGGGDRVTITCRASQSVSSAVAWYQQKPGKAPKLLIYSASSLYSGVPSRFSGSRSGTDFTLTISSLQPEDFATYYCQQSYYYPITFGQGTKVE",
-        Path("/workspaces/chai-lab/pdb70.m8"),
-    ):
-        pass


### PR DESCRIPTION
## Description
- Loosen a check on m8 templates path being a non-empty file.
- Cleanup some old debugging code

## Motivation
When a template search returns no hits (e.g., given some random test sequence), the resulting m8 file can have nothing written into it. Previously, this would trigger an unwanted crash; this now simply returns no templates as expected.

## Test plan
Tested locally.
