### PR TITLE
Bugfix for non-paired MSAs, adjust return types

### DIFF
--- a/chai_lab/data/dataset/msas/colabfold.py
+++ b/chai_lab/data/dataset/msas/colabfold.py
@@ -404,12 +404,13 @@ def generate_colabfold_msas(
             )
             unique_paired_msa_seqs = set(paired_msa_seqs)
 
-            # Non-paired MSA sequences that weren't already covered in the paired MSA; skip header
+            # Non-paired MSA sequences that weren't already covered in the paired MSA
+            # If there were paired MSAs, then skip the header to avoid duplication
             single_fasta: list[Fasta] = [
                 record
                 for i, record in enumerate(read_fasta(single_a3m_path))
                 if (
-                    i > 0
+                    (len(paired_headers) == 0 or i > 0)
                     and not _is_padding_msa_row(record.sequence)
                     and record.sequence not in unique_paired_msa_seqs
                 )

--- a/chai_lab/data/dataset/msas/colabfold.py
+++ b/chai_lab/data/dataset/msas/colabfold.py
@@ -299,7 +299,7 @@ def generate_colabfold_msas(
     msa_server_url: str,
     search_templates: bool = False,
     write_a3m_to_msa_dir: bool = False,  # Useful for manual inspection + debugging
-):
+) -> dict[str, Path]:
     """
     Generate MSAs using the ColabFold (https://github.com/sokrypton/ColabFold)
     server. No-op if no protein sequences are given.
@@ -317,7 +317,7 @@ def generate_colabfold_msas(
     assert not any(msa_dir.iterdir()), "MSA directory must be empty"
     if not protein_seqs:
         logger.warning("No protein sequences for MSA generation; this is a no-op.")
-        return
+        return {}
 
     with tempfile.TemporaryDirectory() as tmp_dir_path:
         tmp_dir = Path(tmp_dir_path)
@@ -381,6 +381,7 @@ def generate_colabfold_msas(
             )
 
         # Process the MSAs into our internal format
+        msa_paths: dict[str, Path] = {}  # Map each sequence to path of aligned pqt
         for protein_seq, pair_msa, single_msa in zip(
             protein_seqs, paired_msas, per_chain_msas, strict=True
         ):
@@ -453,3 +454,5 @@ def generate_colabfold_msas(
                 # If we have a homomer, we might see the same chain multiple
                 # times. The MSAs should be identical for each.
                 aligned_df.to_parquet(msa_path)
+                msa_paths[protein_seq] = msa_path
+    return msa_paths

--- a/chai_lab/data/dataset/msas/load.py
+++ b/chai_lab/data/dataset/msas/load.py
@@ -33,10 +33,12 @@ def get_msa_contexts(
     """
     Looks inside msa_directory to find .aligned.pqt files to load alignments from.
 
-    Returns two contexts
-
+    Returns two contexts:
     - First context to tokenize and give to model
     - Second context for computing summary statistics
+
+    NOTE argument is a msa directory path (not a mapping from sequence to MSA path)
+    in order to handle cases of custom MSAs
     """
 
     pdb_ids = set(chain.entity_data.pdb_id for chain in chains)

--- a/chai_lab/data/dataset/msas/msa_context.py
+++ b/chai_lab/data/dataset/msas/msa_context.py
@@ -12,7 +12,10 @@ from chai_lab.data.parsing.msas.data_source import (
     MSADataSource,
     msa_dataset_source_to_int,
 )
-from chai_lab.data.residue_constants import residue_types_with_nucleotides_order
+from chai_lab.data.residue_constants import (
+    residue_types_with_nucleotides,
+    residue_types_with_nucleotides_order,
+)
 from chai_lab.utils.defaults import default
 from chai_lab.utils.typing import Bool, Int32, UInt8, typecheck
 
@@ -62,6 +65,11 @@ class MSAContext:
             [-1 if x is None else x for x in row_indices_with_nones], dtype=torch.long
         )  # idx=-1 for new sequence
         return padded[filled_indices, :]
+
+    def ith_sequence(self, idx: int) -> str:
+        """Gets the sequence for the ith row of the MSA; useful for debugging/testing."""
+        residues = [residue_types_with_nucleotides[i] for i in self.tokens[idx]]
+        return "".join(residues)
 
     def pad(
         self,

--- a/tests/test_colabfold_msas.py
+++ b/tests/test_colabfold_msas.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from chai_lab.data.dataset.msas.colabfold import generate_colabfold_msas
+from chai_lab.data.dataset.msas.msa_context import MSAContext
 from chai_lab.data.parsing.msas.aligned_pqt import parse_aligned_pqt_to_msa_context
 
 
@@ -13,10 +14,9 @@ def test_monomer():
     sequence = "GPKAMAETRECIYYNANWELERTNQSGLERCEGEQDKRLHCYASWRNSSGTIELVKKGCWLDDFNCYDRQECVATEENPQVYFCCCEGNFCNERFTHLP"
 
     with TemporaryDirectory() as tmpdir:
-        tmpdirpath = Path(tmpdir)
         seq_to_aligned_pqt = generate_colabfold_msas(
             [sequence],
-            msa_dir=tmpdirpath,
+            msa_dir=Path(tmpdir),
             msa_server_url="https://api.colabfold.com",
             search_templates=False,
         )
@@ -25,7 +25,28 @@ def test_monomer():
 
         (pqt_file,) = seq_to_aligned_pqt.values()
         assert pqt_file.exists()
-        ctx = parse_aligned_pqt_to_msa_context(pqt_file)
+        ctx: MSAContext = parse_aligned_pqt_to_msa_context(pqt_file)
 
         # First row of the context should correspond to
         assert ctx.ith_sequence(0) == sequence
+
+
+def test_multimer():
+    sequences = [
+        "GPKAMAETRECIYYNANWELERTNQSGLERCEGEQDKRLHCYASWRNSSGTIELVKKGCWLDDFNCYDRQECVATEENPQVYFCCCEGNFCNERFTHLP",
+        "QVQLVQSGAEVKKPGASVKVSCKASGYTFTSSYINWVRQAPGQGLEWMGTINPVSGSTSYAQKFQGRVTMTRDTSISTAYMELSRLRSDDTAVYYCARGGWFDYWGQGTLVTVSSHHHHHH",
+    ]
+
+    with TemporaryDirectory() as tmpdir:
+        seq_to_aligned_pqt = generate_colabfold_msas(
+            sequences,
+            msa_dir=Path(tmpdir),
+            msa_server_url="https://api.colabfold.com",
+            search_templates=False,
+        )
+        assert len(seq_to_aligned_pqt) == 2
+        for seq in sequences:
+            pqt_file = seq_to_aligned_pqt[seq]
+            ctx: MSAContext = parse_aligned_pqt_to_msa_context(pqt_file)
+            assert ctx.depth > 1
+            assert ctx.ith_sequence(0) == seq

--- a/tests/test_colabfold_msas.py
+++ b/tests/test_colabfold_msas.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for details.
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from chai_lab.data.dataset.msas.colabfold import generate_colabfold_msas
+from chai_lab.data.parsing.msas.aligned_pqt import parse_aligned_pqt_to_msa_context
+
+
+def test_monomer():
+    sequence = "GPKAMAETRECIYYNANWELERTNQSGLERCEGEQDKRLHCYASWRNSSGTIELVKKGCWLDDFNCYDRQECVATEENPQVYFCCCEGNFCNERFTHLP"
+
+    with TemporaryDirectory() as tmpdir:
+        tmpdirpath = Path(tmpdir)
+        seq_to_aligned_pqt = generate_colabfold_msas(
+            [sequence],
+            msa_dir=tmpdirpath,
+            msa_server_url="https://api.colabfold.com",
+            search_templates=False,
+        )
+        assert len(seq_to_aligned_pqt) == 1
+        assert next(iter(seq_to_aligned_pqt.keys())) == sequence
+
+        (pqt_file,) = seq_to_aligned_pqt.values()
+        assert pqt_file.exists()
+        ctx = parse_aligned_pqt_to_msa_context(pqt_file)
+
+        # First row of the context should correspond to
+        assert ctx.ith_sequence(0) == sequence


### PR DESCRIPTION
## Description
- Adjust MSA code to return mapping from sequence to aligned parquet. This makes it easier to work with the MSAs downstream.
- Fix a bug where MSAs queried with a single sequence (i.e., not triggering pairing logic) would still have the first result corresponding to the query dropped.

## Motivation
Bugfix for non-paired MSA searches.

## Test plan
Added unit tests; verified that test fails before fix.
