### PR TITLE
Use full typer

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # CLI, administrator tools
-typer-slim~=0.12        # CLI generator
+typer~=0.12          # CLI generator
 # pydantic~=2.5      # serialization/deserialization of configs
 
 # seaborn


### PR DESCRIPTION
## Motivation
We've observed the following error when both `typer` and `typer-slim` are installed:
```
TypeError: TyperOption.__init__() got an unexpected keyword argument  'flag_value':
```
