### PR TITLE
Fix corner case when template server is enabled with no protein entities

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -380,7 +380,7 @@ def make_all_atom_feature_context(
             msa_server_url=msa_server_url,
         )
         if use_templates_server and protein_sequences:
-            # # Override templates path with server path
+            # Override templates path with server path
             assert templates_path is None
             templates_path = msa_dir / "all_chain_templates.m8"
             assert templates_path.is_file()


### PR DESCRIPTION
## Description
Fix a corner case where if template server was enabled for an input with no protein entities, prediction would crash when trying to find a non-existent template file.

## Motivation
Bugfix for an issue discovered while investigating #351 

## Test plan
Tested locally by running:
```bash
chai-lab fold input.fasta output --use-msa-server --use-templates-server
```
on the following input:
```
>rna|name=R1107
GGGGGCCACAGCAGAAGCGUUCACGUCGCAGCCCCUGUCAGCCAUUGCACUCCGGCUGCGAAUUCUGCU
```
