### PR TITLE
Remove threads argument from `kalign`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install apt-get dependencies
+        run: sudo apt-get install -y kalign
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/chai_lab/tools/kalign.py
+++ b/chai_lab/tools/kalign.py
@@ -43,7 +43,7 @@ class KalignAlignment:
 
     @property
     def reference_span(self) -> tuple[int, int]:
-        """span of the reference that is matched by the query; inclusive on both ends.
+        """Span of the reference matched by the query; inclusive on both ends.
 
         Includes middle gaps, but excludes trailing gaps."""
         reference_positions_covered = set()

--- a/chai_lab/tools/kalign.py
+++ b/chai_lab/tools/kalign.py
@@ -43,7 +43,7 @@ class KalignAlignment:
 
     @property
     def reference_span(self) -> tuple[int, int]:
-        """The span of the reference that is matched by the query.
+        """span of the reference that is matched by the query; inclusive on both ends.
 
         Includes middle gaps, but excludes trailing gaps."""
         reference_positions_covered = set()
@@ -60,9 +60,7 @@ class KalignAlignment:
 # NOTE caching here helps in the case of dimers that have the same chain sequence that
 # we process twice in a row. This allows us to not re-compute alignments.
 @lru_cache(maxsize=1024)
-def kalign_query_to_reference(
-    ref: str, query: str, threads: int = 1
-) -> KalignAlignment | None:
+def kalign_query_to_reference(ref: str, query: str) -> KalignAlignment | None:
     """Align the query to the reference; ignores all insertions (lower case) and
     deletions (- gaps) in the query. This happens by casting all inputs to upper case
     and removing all - chars.
@@ -89,8 +87,6 @@ def kalign_query_to_reference(
             str(fasta_path),
             "-o",
             str(out_path),
-            "--nthreads",
-            str(threads),
         ]
         logger.debug(f"Running kalign: {command}")
         try:

--- a/tests/test_kalign.py
+++ b/tests/test_kalign.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Chai Discovery, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file for details.
+
+from chai_lab.tools.kalign import kalign_query_to_reference
+
+
+def test_all_matches():
+    ref = "RKDES"
+    query = "RKDDS"
+    alignment = kalign_query_to_reference(ref, query)
+    assert alignment is not None
+
+    assert alignment.reference_aligned == ref
+    assert alignment.query_aligned == alignment.query_a3m_line == query
+    assert alignment.reference_span == (0, 4)


### PR DESCRIPTION
## Description
Removes the `threads` argument from `kalign` (which was always set to 1 anyway).

## Motivation
Improve compatibility, fixes #353 

## Test plan
Added test.

