### PR TITLE
remove seq corruption logic, do not map D-AAs to their L-partners

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -174,12 +174,7 @@ feature_generators = dict(
     RelativeTokenSeparation=RelativeTokenSeparation(r_max=32),
     RelativeEntity=RelativeEntity(),
     RelativeChain=RelativeChain(),
-    ResidueType=ResidueType(
-        min_corrupt_prob=0.0,
-        max_corrupt_prob=0.0,
-        num_res_ty=32,
-        key="token_residue_type",
-    ),
+    ResidueType=ResidueType(num_res_ty=32, key="token_residue_type"),
     ESMEmbeddings=ESMEmbeddings(),  # TODO: this can probably be the identity
     BlockedAtomPairDistogram=BlockedAtomPairDistogram(),
     InverseSquaredBlockedAtomPairDistances=BlockedAtomPairDistances(

--- a/chai_lab/data/features/generators/residue_type.py
+++ b/chai_lab/data/features/generators/residue_type.py
@@ -2,20 +2,16 @@
 # Licensed under the Apache License, Version 2.0.
 # See the LICENSE file for details.
 
-import numpy as np
-import torch
 from torch import Tensor
 
 from chai_lab.data.features.feature_type import FeatureType
 from chai_lab.data.features.generators.base import EncodingType, FeatureGenerator
-from chai_lab.utils.typing import Bool, Int, typecheck
+from chai_lab.utils.typing import Int, typecheck
 
 
 class ResidueType(FeatureGenerator):
     def __init__(
         self,
-        min_corrupt_prob: float = 0.0,
-        max_corrupt_prob: float = 0.0,
         num_res_ty: int = 22,  # 20AA + gap + X
         key: str = "aatype",
     ):
@@ -26,25 +22,7 @@ class ResidueType(FeatureGenerator):
             num_classes=num_res_ty,
             mult=1,
         )
-        self.min_corrupt_prob = min_corrupt_prob
-        self.max_corrupt_prob = max_corrupt_prob
         self.key = key
-
-    @typecheck
-    def _corrupt_seq(
-        self, sequence: Int[Tensor, "... n"]
-    ) -> tuple[Int[Tensor, "... n"], Bool[Tensor, "... n"]]:
-        """Corrupt the sequence with the given probability"""
-        corrupt_prob = np.random.uniform(
-            low=self.min_corrupt_prob, high=self.max_corrupt_prob
-        )
-        corrupt_mask = torch.rand_like(sequence.float()) < corrupt_prob
-        corrupt_aas = torch.randint_like(
-            corrupt_mask[corrupt_mask].long(), high=self.num_classes - 1
-        )
-        corrupt_sequence = sequence.clone()
-        corrupt_sequence[corrupt_mask] = corrupt_aas
-        return corrupt_sequence, corrupt_mask
 
     def get_input_kwargs_from_batch(self, batch) -> dict:
         return dict(aatype=batch["inputs"][self.key].long())
@@ -53,5 +31,4 @@ class ResidueType(FeatureGenerator):
     def _generate(self, aatype: Int[Tensor, "b n"]) -> Tensor:
         """see super class"""
         seq_emb = aatype.clone()
-        seq_emb, _corrupt_mask = self._corrupt_seq(seq_emb)
         return self.make_feature(data=seq_emb.unsqueeze(-1))

--- a/chai_lab/data/parsing/structure/sequence.py
+++ b/chai_lab/data/parsing/structure/sequence.py
@@ -11,6 +11,29 @@ from chai_lab.data.parsing.structure.entity_type import EntityType
 
 logger = logging.getLogger(__name__)
 
+D_partners = {
+    "DAL": "D-ALANINE",
+    "DAR": "D-ARGININE",
+    "DAS": "D-ASPARTIC ACID",
+    "DCY": "D-CYSTEINE",
+    "DGL": "D-GLUTAMIC ACID",
+    "DGN": "D-GLUTAMINE",
+    "DHI": "D-HISTIDINE",
+    "DIL": "D-ISOLEUCINE",
+    "DLE": "D-LEUCINE",
+    "DLY": "D-LYSINE",
+    "DPN": "D-PHENYLALANINE",
+    "DPR": "D-PROLINE",
+    "DSG": "D-ASPARAGINE",
+    "DSN": "D-SERINE",
+    "DTH": "D-THREONINE",
+    "DTR": "D-TRYPTOPHAN",
+    "DTY": "D-TYROSINE",
+    "DVA": "D-VALINE",
+    "FGA": "GAMMA-D-GLUTAMIC ACID",
+    "MED": "D-METHIONINE",
+}
+
 
 def fasta_one_letter_sequence(residue_codes: list[str]) -> str:
     """
@@ -52,6 +75,8 @@ def _get_protein_only_residue_token(
 ) -> str:
     """Encodes everything that is not a standard amino acid as X if nonstandard_as_X is
     True, otherwise return nonstandard FOO as [FOO]"""
+    if three_letter_code in D_partners:
+        return "X"
     residue_info = gemmi.find_tabulated_residue(three_letter_code)
     # Standard amino acids are always given as single letters
     if residue_info.is_amino_acid() and residue_info.is_standard():


### PR DESCRIPTION
## Description

- seq corruption not needed
- prevent mapping of D-aminoacids to their L-partners, as unlikely there is much structural similarity


## Test plan

tested on example inputs that X is passed to ESM, very little effect:

```
>protein|name=prot1
SEQ(DPN)RESTS
>protein|name=prot2
SEQFRESTT
```

