### PR TITLE
Enable customizing template_cif_cache_folder

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -351,6 +351,7 @@ def make_all_atom_feature_context(
     constraint_path: Path | None = None,
     use_templates_server: bool = False,
     templates_path: Path | None = None,
+    template_cif_cache_folder: Path | None = None,
     esm_device: torch.device = torch.device("cpu"),
 ):
     assert not (
@@ -437,7 +438,7 @@ def make_all_atom_feature_context(
             chains=chains,
             use_sequence_hash_for_lookup=use_templates_server,
             template_hits_m8=templates_path,
-            template_cif_cache_folder=output_dir / "templates",
+            template_cif_cache_folder=template_cif_cache_folder or (output_dir / "templates"),
         )
 
     # Load ESM embeddings
@@ -511,6 +512,7 @@ def run_inference(
     constraint_path: Path | None = None,
     use_templates_server: bool = False,
     template_hits_path: Path | None = None,
+    template_cif_cache_folder: Path | None = None,
     # Parameters controlling how we do inference
     recycle_msa_subsample: int = 0,
     num_trunk_recycles: int = 3,
@@ -539,6 +541,7 @@ def run_inference(
         constraint_path=constraint_path,
         use_templates_server=use_templates_server,
         templates_path=template_hits_path,
+        template_cif_cache_folder=template_cif_cache_folder,
         esm_device=torch_device,
     )
 


### PR DESCRIPTION
## Description

Add optional `template_cif_cache_folder` argument to `run_inference` to enable using a local directory with internal templates, and to avoid re-downloading if templates are often reused.

## Motivation

Current implementation doesn't enable using in-house structures or de-novo designed structures as templates. This simple change enables that.

## Test plan

No tests yet
