### PR TITLE
Allow restraints w.r.t. entity name-based subchains; fix parsing with empty comments

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -528,7 +528,7 @@ def run_inference(
 
     torch_device = torch.device(device if device is not None else "cuda:0")
 
-    # NOTE if fastas are cif chain names, we use this to parse chains as well
+    # NOTE if fastas are cif chain names, we also use them to parse chains and restraints
     feature_context = make_all_atom_feature_context(
         fasta_file=fasta_file,
         output_dir=output_dir,

--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -339,6 +339,7 @@ def make_all_atom_feature_context(
     fasta_file: Path,
     *,
     output_dir: Path,
+    entity_name_as_subchain: bool = False,
     use_esm_embeddings: bool = True,
     use_msa_server: bool = False,
     msa_server_url: str = "https://api.colabfold.com",
@@ -368,7 +369,9 @@ def make_all_atom_feature_context(
             )
 
     # Load structure context
-    chains = load_chains_from_raw(fasta_inputs)
+    chains = load_chains_from_raw(
+        fasta_inputs, entity_name_as_subchain=entity_name_as_subchain
+    )
     del fasta_inputs  # Do not reference inputs after creating chains from them
 
     merged_context = AllAtomStructureContext.merge(
@@ -525,9 +528,11 @@ def run_inference(
 
     torch_device = torch.device(device if device is not None else "cuda:0")
 
+    # NOTE if fastas are cif chain names, we use this to parse chains as well
     feature_context = make_all_atom_feature_context(
         fasta_file=fasta_file,
         output_dir=output_dir,
+        entity_name_as_subchain=fasta_names_as_cif_chains,
         use_esm_embeddings=use_esm_embeddings,
         use_msa_server=use_msa_server,
         msa_server_url=msa_server_url,

--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -520,6 +520,12 @@ def run_inference(
     # IO options
     fasta_names_as_cif_chains: bool = False,
 ) -> StructureCandidates:
+    """Runs inference on sequences in the provided fasta file.
+
+    Important notes:
+    - If fasta_names_as_cif_chains is True, fasta entity names are used for parsing
+      and writing chains. Restraints must ALSO be named w.r.t. fasta names.
+    """
     assert num_trunk_samples > 0 and num_diffn_samples > 0
     if output_dir.exists():
         assert not any(

--- a/chai_lab/data/dataset/inference_dataset.py
+++ b/chai_lab/data/dataset/inference_dataset.py
@@ -92,7 +92,9 @@ def _synth_subchain_id(idx: int) -> str:
 
 
 def raw_inputs_to_entitites_data(
-    inputs: list[Input], identifier: str = "test"
+    inputs: list[Input],
+    entity_name_as_subchain: bool = False,
+    identifier: str = "test",
 ) -> list[AllAtomEntityData]:
     """Load an entity for each raw input."""
     entities = []
@@ -153,12 +155,20 @@ def raw_inputs_to_entitites_data(
                 resolution=0.0,
                 release_datetime=datetime.now(),
                 pdb_id=identifier,
-                source_pdb_chain_id=_synth_subchain_id(i),
+                source_pdb_chain_id=(
+                    _synth_subchain_id(i)
+                    if not entity_name_as_subchain
+                    else input.entity_name
+                ),
                 entity_name=input.entity_name,
                 entity_id=entity_id,
                 method="none",
                 entity_type=entity_type,
-                subchain_id=_synth_subchain_id(i),
+                subchain_id=(
+                    _synth_subchain_id(i)
+                    if not entity_name_as_subchain
+                    else input.entity_name
+                ),
                 original_record=input.sequence,
             )
         )
@@ -170,6 +180,7 @@ def raw_inputs_to_entitites_data(
 def load_chains_from_raw(
     inputs: list[Input],
     identifier: str = "test",
+    entity_name_as_subchain: bool = False,
     tokenizer: AllAtomResidueTokenizer | None = None,
 ) -> list[Chain]:
     """
@@ -183,6 +194,7 @@ def load_chains_from_raw(
     # Extract the entity data from the gemmi structure.
     entities: list[AllAtomEntityData] = raw_inputs_to_entitites_data(
         inputs,
+        entity_name_as_subchain=entity_name_as_subchain,
         identifier=identifier,
     )
 

--- a/chai_lab/data/parsing/restraints.py
+++ b/chai_lab/data/parsing/restraints.py
@@ -166,7 +166,7 @@ def _parse_row(row: pd.Series) -> PairwiseInteraction:
         min_dist_angstrom=row["min_distance_angstrom"],
         connection_type=PairwiseInteractionType(row["connection_type"]),
         confidence=row["confidence"],
-        comment=row["comment"],
+        comment="" if pd.isna(row["comment"]) else row["comment"],
     )
 
 

--- a/tests/test_inference_dataset.py
+++ b/tests/test_inference_dataset.py
@@ -104,3 +104,20 @@ def test_protein_with_smiles(tokenizer: AllAtomResidueTokenizer):
         example.token_entity_type == EntityType.LIGAND.value
     ]
     assert torch.unique(lig_sym_ids).numel() == 2  # Two copies of each ligand
+
+
+def test_entity_names_as_subchain(tokenizer: AllAtomResidueTokenizer):
+    inputs = [
+        Input(sequence="RKDES", entity_type=EntityType.PROTEIN.value, entity_name="X"),
+        Input(sequence="GHGHGH", entity_type=EntityType.PROTEIN.value, entity_name="Y"),
+    ]
+
+    chains = load_chains_from_raw(
+        inputs=inputs, entity_name_as_subchain=False, tokenizer=tokenizer
+    )
+    assert [chain.entity_data.subchain_id for chain in chains] == ["A", "B"]
+
+    chain_manual_named = load_chains_from_raw(
+        inputs=inputs, entity_name_as_subchain=True, tokenizer=tokenizer
+    )
+    assert [chain.entity_data.subchain_id for chain in chain_manual_named] == ["X", "Y"]

--- a/tests/test_restraints.py
+++ b/tests/test_restraints.py
@@ -98,7 +98,8 @@ def test_restraints_with_manual_chain_names(entity_name_as_subchain: bool):
     contact_ft_all_null = torch.allclose(contact_ft, torch.tensor(-1).float())
 
     if entity_name_as_subchain:
-        # Loaded correctly, there are
+        # Loaded correctly, so some should not be null
         assert not contact_ft_all_null
     else:
+        # Did not load; all null
         assert contact_ft_all_null

--- a/tests/test_restraints.py
+++ b/tests/test_restraints.py
@@ -42,7 +42,7 @@ def test_loading_restraints():
     [True, False],
 )
 def test_restraints_with_manual_chain_names(entity_name_as_subchain: bool):
-    """when entity name is used as chain name, restraints are also specified by entity name."""
+    """when entity name is used as chain name, restraints are given w.r.t. entity name."""
     inputs = [
         Input("GGGGGG", entity_type=EntityType.PROTEIN.value, entity_name="G"),
         Input("HHHHHH", entity_type=EntityType.PROTEIN.value, entity_name="H"),

--- a/tests/test_restraints.py
+++ b/tests/test_restraints.py
@@ -57,7 +57,16 @@ def test_restraints_with_manual_chain_names(entity_name_as_subchain: bool):
             res_idxB="H1",
             atom_nameB="",
             connection_type=PairwiseInteractionType.CONTACT,
-        )
+        ),
+        PairwiseInteraction(
+            chainA="G",
+            res_idxA="",
+            atom_nameA="",
+            chainB="H",
+            res_idxB="H1",
+            atom_nameB="",
+            connection_type=PairwiseInteractionType.POCKET,
+        ),
     ]
 
     chains = load_chains_from_raw(
@@ -96,10 +105,14 @@ def test_restraints_with_manual_chain_names(entity_name_as_subchain: bool):
     ft = batch["features"]
     contact_ft = ft["TokenDistanceRestraint"]
     contact_ft_all_null = torch.allclose(contact_ft, torch.tensor(-1).float())
+    pocket_ft = ft["TokenPairPocketRestraint"]
+    pocket_ft_all_null = torch.allclose(pocket_ft, torch.tensor(-1).float())
 
     if entity_name_as_subchain:
         # Loaded correctly, so some should not be null
         assert not contact_ft_all_null
+        assert not pocket_ft_all_null
     else:
         # Did not load; all null
         assert contact_ft_all_null
+        assert pocket_ft_all_null


### PR DESCRIPTION
## Description
Allow restraints to be specified w.r.t. fasta-based chain naming.

## Motivation
Like in #378 this allows for more consistent and predictable chain naming behavior, streamlining post hoc analysis.

## Test plan
Added tests to ensure that fasta and restraint parsing have expected compatibility combinations (e.g., if they are mismatched they shouldn't load, if they are matched they should load). 
