### PR TITLE
Allow torch 2.7 - tested to work correctly with 2.7.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -28,4 +28,4 @@ numba>=0.59
 einops~=0.8
 jaxtyping>=0.2.25   # versions <0.2.25 do not easily support runtime typechecking
 beartype>=0.18      # compatible typechecker to use with jaxtyping
-torch>=2.3.1,<2.7   # 2.2 is broken, 2.3.1 is confirmed to work correctly
+torch>=2.3.1        # 2.2 is broken, 2.3.1 is confirmed to work correctly


### PR DESCRIPTION
## Description
See title.

## Motivation
Wider compatibility.

## Test plan
Ran examples locally with torch 2.7.1; outputs look as expected.
