### PR TITLE
ci: don't run tests when only markdown files are changed on a push

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
   # Triggered whenever a PR is opened or updated
   pull_request:
 jobs:


### PR DESCRIPTION
## Description
Currently, the `Pytest` CI workflow will run even when a push changes **only markdown files** (e.g., README.md).

With the proposed changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

## Motivation
Here is an example of the behaviour described above: the commit [`39520c8`](https://github.com/chaidiscovery/chai-lab/commit/39520c87a11cf84691cc2fddc2f4fad7870956b1) changed these files: `README.md` and, when pushed, triggered [this](https://github.com/chaidiscovery/chai-lab/actions/runs/13421816588) workflow run, which ran for ~2 CPU minutes. With the proposed changes, these 2 CPU minutes would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general. 

Note that this is a single example out of **9 examples** over the last few months; a lower estimate for the accumulated gain is **30 CPU minutes**, but the actual number could be higher because our cutoff date is late May and our data go only a few months back.

This only affects the `push` trigger and not the `pull_request` trigger, so the actions related to pull requests (opening, pushing new commits on an open PR, closing) will not be affected, only the pushes to branches which do not have an open pull request.

<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit 39520c8](https://github.com/chaidiscovery/chai-lab/commit/39520c8) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/13421816588)
[commit 0c7cfd5](https://github.com/chaidiscovery/chai-lab/commit/0c7cfd5) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/12054171427)
[commit 8fd2f8d](https://github.com/chaidiscovery/chai-lab/commit/8fd2f8d) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/11964078787)
[commit 1c3ff6b](https://github.com/chaidiscovery/chai-lab/commit/1c3ff6b) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/11887097251)
[commit a25da25](https://github.com/chaidiscovery/chai-lab/commit/a25da25) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/11445170383)
[commit 4fbd82a](https://github.com/chaidiscovery/chai-lab/commit/4fbd82a) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/11445138910)
[commit 55c732e](https://github.com/chaidiscovery/chai-lab/commit/55c732e) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/12055738083)
[commit bed1b68](https://github.com/chaidiscovery/chai-lab/commit/bed1b68) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/11963973966)
[commit 400fc4f](https://github.com/chaidiscovery/chai-lab/commit/400fc4f) => [run url](https://github.com/chaidiscovery/chai-lab/actions/runs/11941194934)

</details>


## Test plan
No testing was performed.
