### PR TITLE
fix: avoid warnings about typing deprecations and escape sequences

### DIFF
--- a/chai_lab/data/dataset/templates/align.py
+++ b/chai_lab/data/dataset/templates/align.py
@@ -4,9 +4,9 @@
 """Helper functions for aligning templates."""
 
 import logging
-from typing import Sequence
 
 import torch
+from beartype.typing import Sequence
 from torch import Tensor
 
 from chai_lab.utils.typing import Shaped, typecheck

--- a/chai_lab/data/dataset/templates/load.py
+++ b/chai_lab/data/dataset/templates/load.py
@@ -21,11 +21,12 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Iterator
+
 
 import gemmi
 import torch
 from aiohttp import ClientResponseError
+from beartype.typing import Iterator
 from torch import Tensor
 from urllib3.exceptions import HTTPError, MaxRetryError
 

--- a/chai_lab/data/parsing/msas/aligned_pqt.py
+++ b/chai_lab/data/parsing/msas/aligned_pqt.py
@@ -9,11 +9,12 @@ import hashlib
 import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal, Mapping, Optional
+from typing import Literal, Optional
 
 import pandas as pd
 import pandera as pa
 import torch
+from beartype.typing import Mapping
 from einops import repeat
 from pandera.typing import Series
 

--- a/chai_lab/ranking/ptm.py
+++ b/chai_lab/ranking/ptm.py
@@ -97,7 +97,7 @@ def interface_ptm(
 ) -> Float[Tensor, "..."]:
     """Compute Interface pTM score
 
-    ipTM is the max TM score over chains c \in C, restricting
+    ipTM is the max TM score over chains c \\in C, restricting
     to interactions between c and C - {c}.
     """
     query_res_mask, _ = get_chain_masks_and_asyms(


### PR DESCRIPTION
## Description
Updates some typing inputs to beartype.typing as directed by warning messages.
Avoids a warning about an escape string by escaping as expected by docstring parser.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Test plan
<!--- Please describe in detail how you tested your changes. -->
