### PR TITLE
ranking/clashes: fix hardcoded batch dim in has_inter_chain_clashes

### DIFF
--- a/chai_lab/ranking/clashes.py
+++ b/chai_lab/ranking/clashes.py
@@ -79,7 +79,7 @@ def has_inter_chain_clashes(
     ).ge(max_clash_ratio)
 
     has_clashes |= (
-        per_chain_pair_clashes / rearrange(atoms_per_chain, "b c -> b 1 c").clamp(min=1)
+        per_chain_pair_clashes / rearrange(atoms_per_chain, "... c -> ... 1 c").clamp(min=1)
     ).ge(max_clash_ratio)
 
     # only consider clashes between pairs of polymer chains


### PR DESCRIPTION
## Description
Replace the hardcoded `"b c -> b 1 c"` einops pattern on line 82 of
`chai_lab/ranking/clashes.py` with the variadic `"... c -> ... 1 c"`,
making it consistent with the parallel rearrange on line 78.

## Motivation
`has_inter_chain_clashes` accepts tensors with variadic batch dims (`...`)
as declared in all its type annotations, and the first ratio check
(line 78) already uses `"... c -> ... c 1"` correctly. The second ratio
check (line 82) used a hardcoded single batch dim `b`, causing an einops
shape mismatch error whenever the function is called with an unbatched
input or with two or more batch dimensions (e.g. samples × diffusion
steps). This crashes the entire ranking step at inference time for those
call shapes.

## Test plan
- Manually verified the fix against the existing call site in `get_scores`
  (same file), which passes `atom_mask` with shape `(b, a)` — confirmed
  both the before and after patterns produce identical results for that
  case.
- Run the fix with an unbatched input (`atoms_per_chain` shape `(c,)`) to
  confirm the old code raises and the new code succeeds.
- Run `pytest tests/` to confirm no regressions in the existing test suite.