### PR TITLE
Fix several latent bugs in MSA, ranking, and structure-context code

### DIFF
--- a/chai_lab/data/dataset/msas/colabfold.py
+++ b/chai_lab/data/dataset/msas/colabfold.py
@@ -61,8 +61,8 @@ def _run_mmseqs2(
             query += f">{n}\n{seq}\n"
             n += 1
 
+        error_count = 0
         while True:
-            error_count = 0
             try:
                 # https://requests.readthedocs.io/en/latest/user/advanced/#advanced
                 # "good practice to set connect timeouts to slightly larger than a multiple of 3"
@@ -95,8 +95,8 @@ def _run_mmseqs2(
         return out
 
     def status(ID):
+        error_count = 0
         while True:
-            error_count = 0
             try:
                 res = requests.get(
                     f"{host_url}/ticket/{ID}", timeout=6.02, headers=headers

--- a/chai_lab/data/dataset/structure/all_atom_structure_context.py
+++ b/chai_lab/data/dataset/structure/all_atom_structure_context.py
@@ -382,7 +382,7 @@ class AllAtomStructureContext:
         token_backbone_frame_index = torch.cat(
             [
                 x.token_backbone_frame_index + count
-                for x, count in zip(contexts, token_offsets)
+                for x, count in zip(contexts, atom_offsets)
             ]
         )
 

--- a/chai_lab/data/features/generators/msa.py
+++ b/chai_lab/data/features/generators/msa.py
@@ -240,7 +240,9 @@ class MSADataSourceGenerator(FeatureGenerator):
         query = msa_dataset_source_to_int[MSADataSource.QUERY]
         none = msa_dataset_source_to_int[MSADataSource.NONE]
         # chai-1 specific: replace QUERY with NONE
-        msa_sequence_source[msa_sequence_source.eq(query)] = none
+        msa_sequence_source = msa_sequence_source.masked_fill(
+            msa_sequence_source.eq(query), none
+        )
         # use none for masking.
         msa_sequence_source = msa_sequence_source.masked_fill(~msa_mask, none)
         return self.make_feature(data=msa_sequence_source.unsqueeze(-1))

--- a/chai_lab/data/features/generators/token_dist_restraint.py
+++ b/chai_lab/data/features/generators/token_dist_restraint.py
@@ -120,11 +120,11 @@ class TokenDistanceRestraint(FeatureGenerator):
             )
         ).long()
         self.key_entity_types = torch.tensor(
-            [
+            (
                 [e.value for e in key_entity_types]
                 if key_entity_types is not None
                 else [e.value for e in EntityType]
-            ]
+            )
         ).long()
 
     def get_num_restraints(self, batch_size) -> list[int]:

--- a/chai_lab/ranking/clashes.py
+++ b/chai_lab/ranking/clashes.py
@@ -79,7 +79,8 @@ def has_inter_chain_clashes(
     ).ge(max_clash_ratio)
 
     has_clashes |= (
-        per_chain_pair_clashes / rearrange(atoms_per_chain, "b c -> b 1 c").clamp(min=1)
+        per_chain_pair_clashes
+        / rearrange(atoms_per_chain, "... c -> ... 1 c").clamp(min=1)
     ).ge(max_clash_ratio)
 
     # only consider clashes between pairs of polymer chains


### PR DESCRIPTION
Fixes 5 small but real bugs found while reviewing the data pipeline, ranking, and feature-generator code. Each is a one- to four-line change.

## Fixes

1. **`colabfold.py`** - `error_count = 0` was inside the `while True` retry loop in `submit()` and `status()`, so the counter reset every iteration and `if error_count > 5: raise` was unreachable. The submit/status helpers would retry forever on persistent server errors. Moved the initialization above the loop. (`download()` was already correct.)

2. **`all_atom_structure_context.py`** - In `AllAtomStructureContext.merge`, `token_backbone_frame_index` (which stores **atom** indices, see `backbone_atoms_indices` in `data/dataset/structure/utils.py`) was being offset by `token_offsets` rather than `atom_offsets` when merging multiple chains. The sibling fields `token_centre_atom_index` and `token_ref_atom_index` in the same function correctly use `atom_offsets`. Currently latent because the returned `frame_idces` from `get_frames_and_mask` is discarded by `chai1.py`, but it's still a real semantic bug.

3. **`token_dist_restraint.py`** - Stray extra `[ ... ]` around the `key_entity_types` tensor literal gave it shape `(1, n)` instead of `(n,)`, asymmetric with `query_entity_types` defined right above it. Currently unused at the call site, but trivially wrong.

4. **`ranking/clashes.py`** - In `has_inter_chain_clashes`, the two ratio checks used inconsistent einops patterns: `"... c -> ... c 1"` (ellipsis-form) on one line and `"b c -> b 1 c"` (hardcoded `b`) on the next. Functionally equivalent for the 2D batch input used today, but the latter will fail if batch dims ever change. Made both ellipsis-form.

5. **`features/generators/msa.py`** - `MSADataSourceGenerator._generate` mutated the input `msa_sequence_source` tensor in place (`msa_sequence_source[msa_sequence_source.eq(query)] = none`) before reassigning it via the non-inplace `masked_fill` on the next line. Idempotent so it doesn't cause incorrect output today, but fragile - replaced with `masked_fill` for consistency.
