### PR TITLE
relax requirement on numpy

### DIFF
--- a/chai_lab/chai1.py
+++ b/chai_lab/chai1.py
@@ -1047,7 +1047,7 @@ def run_folding_on_context(
 
         scores_out_path = output_dir.joinpath(f"scores.model_idx_{idx}.npz")
 
-        np.savez(scores_out_path, **get_scores(ranking_outputs))
+        np.savez(scores_out_path, allow_pickle=False, **get_scores(ranking_outputs))
 
     return StructureCandidates(
         cif_paths=cif_paths,

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ modelcif>=1.0      # mmcif writing, confirmed to work currently latest 1.0
 
 
 # computing, dl
-numpy~=1.21
+numpy>=1.21
 pandas[parquet,gcp,aws]~=2.1 
 pandera>=0.24       # pandera.pandas requires >= 0.24
 numba>=0.59


### PR DESCRIPTION
## Description

allow using numpy >= 2.

## Motivation

numpy 1.* support is over

## Test plan

```
python examples/predict_structure.py
# and confirmed structures look ok
```

```
uv pip freeze | grep numpy
Using Python 3.10.12 environment at /opt/venv
numpy==2.2.6
```